### PR TITLE
ci: fix setup-node cache for pnpm (no package-lock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
+
       - name: Enable corepack
         run: corepack enable
       - name: Install
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
+
       - name: Enable corepack
         run: corepack enable
       - name: Install
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
+
       - name: Enable corepack
         run: corepack enable
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
+
       - name: Enable corepack
         run: corepack enable
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
setup-node cache=npm requires package-lock.json, which we removed when migrating to pnpm. Remove cache settings for now so CI doesn't hard-fail; we can add a proper pnpm-store cache later.