### PR TITLE
M1(web): context/namespace banner + /explore shell (kinds/resources)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# Telescope Squad (AI Agentic Team)
+
+This repo is intended to be built by an *agentic* AI team. This file defines the **roles**, **interfaces**, and **quality gates** that keep the team honest.
+
+## Non‑negotiables
+- **No Electron**. Desktop is **Tauri + native WebView**.
+- **Deterministic CI**: no live AKS/K8s dependency in PR CI.
+- **Container-only local validation** before pushing (use `scripts/dev-test.sh`).
+- **No “green CI with zero tests.”** Every milestone increment expands tests.
+- **Two-reviewer rule for agent work**: every non-trivial PR gets review by **two independent reviewer agents** (see “Review protocol”).
+
+---
+
+## Roles (the Squad)
+
+### Tech Lead (TL)
+Owns architecture, sequencing, and “smallest safe change.”
+- Maintains API contracts and keeps UI/engine boundaries clean.
+- Ensures memory efficiency constraints are respected.
+
+### Web Engineer
+Implements SvelteKit UI + tests.
+- Uses URL-driven state and virtualization where lists are large.
+
+### Desktop Engineer
+Owns Tauri packaging/build stability.
+- Keeps Win/Mac builds green; Linux desktop deps must not leak into Rust CI.
+
+### Engine Engineer (Rust)
+Owns deterministic engine behavior and contracts.
+- Provides stubs/fixtures for CI and test harnesses.
+
+### QA / Test Engineer
+Owns test strategy and anti-flake rules.
+- Prefers **stub servers** + fixtures for E2E over brittle request interception.
+
+### Security Engineer
+Owns dependency hygiene + SDL basics.
+- Tracks vulnerabilities and defines upgrade playbooks.
+
+### Release/CI Engineer
+Owns GitHub Actions + release workflow.
+- CI should fail fast with actionable output.
+
+### UX / Performance
+Owns performance-first UX.
+- “Virtualize everything”, skeletons not blocking spinners, keyboard-first.
+
+---
+
+## Review protocol (anti-hallucination)
+For each PR:
+1) **Author agent** ships the change with tests.
+2) **Reviewer agent A** performs a code review focused on correctness + API contract adherence.
+3) **Reviewer agent B** performs a code review focused on tests + determinism + flake risks.
+
+Reviewers must:
+- Point to concrete lines/files.
+- Call out any “made up” behavior (missing endpoints, nonexistent config keys, etc.).
+- Reject changes that bypass the container-only dev loop.
+
+---
+
+## Learning capture
+When we learn something (CI edge case, Tauri quirk, flaky E2E pattern), we record it in:
+- `docs/retrospectives/*` (milestone retros)
+- this file (process / team learnings)
+
+Keep it short. Make it actionable.

--- a/apps/web/src/lib/components/ContextBanner.svelte
+++ b/apps/web/src/lib/components/ContextBanner.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import type { Cluster, Namespace } from '$lib/engine';
+
+  export let clusterId: string;
+  export let clusters: Cluster[];
+  export let namespaces: Namespace[];
+  export let namespace: string;
+
+  const selected = () => clusters.find((c) => c.id === clusterId);
+</script>
+
+<div class="banner" data-testid="context-banner">
+  <div class="left">
+    <span class="label">Cluster</span>
+    <span class="value" data-testid="cluster-name">{selected()?.name ?? clusterId}</span>
+    <span class="muted">({clusterId})</span>
+  </div>
+
+  <div class="right">
+    <label class="ns">
+      <span class="label">Namespace</span>
+      <select
+        data-testid="namespace-select"
+        bind:value={namespace}
+        on:change={(e) => {
+          const ns = (e.currentTarget as HTMLSelectElement).value;
+          const u = new URL(window.location.href);
+          u.searchParams.set('namespace', ns);
+          window.history.replaceState({}, '', u);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }}
+      >
+        {#each namespaces as ns}
+          <option value={ns.name}>{ns.name}</option>
+        {/each}
+      </select>
+    </label>
+  </div>
+</div>
+
+<style>
+  .banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 12px;
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    background: #111;
+  }
+  .left,
+  .right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .label {
+    font-size: 12px;
+    color: #aaa;
+  }
+  .value {
+    font-weight: 600;
+  }
+  .muted {
+    font-size: 12px;
+    color: #888;
+  }
+  select {
+    background: #0b0b0b;
+    color: #eee;
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 6px 8px;
+  }
+</style>

--- a/apps/web/src/lib/engine.ts
+++ b/apps/web/src/lib/engine.ts
@@ -1,18 +1,81 @@
-export type Cluster = {
-  id: string;
-  name: string;
-  context?: string;
-  server?: string;
+export type Cluster = { id: string; name: string };
+export type Namespace = { name: string };
+
+export type Kind = {
+  /** Display name */
+  kind: string;
+  /** If false, treat as cluster-scoped (ignore namespace). */
+  namespaced: boolean;
 };
 
-export async function listClusters(fetchFn: typeof fetch): Promise<Cluster[]> {
-  const res = await fetchFn('/api/clusters', {
-    headers: { accept: 'application/json' }
-  });
-  if (!res.ok) {
-    throw new Error(`GET /api/clusters failed: ${res.status}`);
-  }
+export type ResourceRow = {
+  name: string;
+  namespace?: string;
+  status?: string;
+  age?: string;
+};
 
-  const body = (await res.json()) as { clusters?: Cluster[] };
-  return body.clusters ?? [];
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+async function getJson<T>(fetchLike: FetchLike, path: string): Promise<T> {
+  const res = await fetchLike(path, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${path}`);
+  return (await res.json()) as T;
+}
+
+// SSR-friendly helper used by +page.ts loaders.
+export async function listClusters(fetchLike: FetchLike): Promise<Cluster[]> {
+  const data = await getJson<{ clusters: Cluster[] }>(fetchLike, '/api/clusters');
+  return data.clusters;
+}
+
+// Browser-friendly helper.
+export async function getClusters(): Promise<Cluster[]> {
+  return listClusters(globalThis.fetch);
+}
+
+export async function listNamespaces(fetchLike: FetchLike, clusterId: string): Promise<Namespace[]> {
+  const data = await getJson<{ namespaces: Namespace[] }>(
+    fetchLike,
+    `/api/namespaces?cluster=${encodeURIComponent(clusterId)}`
+  );
+  return data.namespaces;
+}
+
+export async function getNamespaces(clusterId: string): Promise<Namespace[]> {
+  return listNamespaces(globalThis.fetch, clusterId);
+}
+
+export async function listKinds(fetchLike: FetchLike): Promise<Kind[]> {
+  const data = await getJson<{ kinds: Kind[] }>(fetchLike, '/api/kinds');
+  return data.kinds;
+}
+
+export async function getKinds(): Promise<Kind[]> {
+  return listKinds(globalThis.fetch);
+}
+
+export async function listResources(
+  fetchLike: FetchLike,
+  params: {
+    clusterId: string;
+    namespace?: string;
+    kind: string;
+  }
+): Promise<ResourceRow[]> {
+  const qs = new URLSearchParams();
+  qs.set('cluster', params.clusterId);
+  qs.set('kind', params.kind);
+  if (params.namespace) qs.set('namespace', params.namespace);
+
+  const data = await getJson<{ items: ResourceRow[] }>(fetchLike, `/api/resources?${qs.toString()}`);
+  return data.items;
+}
+
+export async function getResources(params: {
+  clusterId: string;
+  namespace?: string;
+  kind: string;
+}): Promise<ResourceRow[]> {
+  return listResources(globalThis.fetch, params);
 }

--- a/apps/web/src/routes/api/kinds/+server.ts
+++ b/apps/web/src/routes/api/kinds/+server.ts
@@ -1,0 +1,26 @@
+import { PUBLIC_ENGINE_HTTP_BASE } from '$env/static/public';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async () => {
+  if (!PUBLIC_ENGINE_HTTP_BASE) {
+    // Deterministic stub set for M1 explorer.
+    return json(
+      {
+        kinds: [
+          { kind: 'Pods', namespaced: true },
+          { kind: 'Deployments', namespaced: true },
+          { kind: 'Services', namespaced: true },
+          { kind: 'ConfigMaps', namespaced: true },
+          { kind: 'Nodes', namespaced: false },
+          { kind: 'Namespaces', namespaced: false }
+        ]
+      },
+      { status: 200 }
+    );
+  }
+
+  const res = await fetch(`${PUBLIC_ENGINE_HTTP_BASE}/api/kinds`, { headers: { accept: 'application/json' } });
+  const body = await res.json().catch(() => ({ kinds: [] }));
+  return json(body, { status: res.status });
+};

--- a/apps/web/src/routes/api/namespaces/+server.ts
+++ b/apps/web/src/routes/api/namespaces/+server.ts
@@ -1,0 +1,20 @@
+import { PUBLIC_ENGINE_HTTP_BASE } from '$env/static/public';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+  const cluster = url.searchParams.get('cluster') ?? '';
+  if (!cluster) return json({ namespaces: [] }, { status: 400 });
+
+  if (!PUBLIC_ENGINE_HTTP_BASE) {
+    // Deterministic stub.
+    return json({ namespaces: [{ name: 'default' }, { name: 'kube-system' }] }, { status: 200 });
+  }
+
+  const res = await fetch(`${PUBLIC_ENGINE_HTTP_BASE}/api/clusters/${encodeURIComponent(cluster)}/namespaces`, {
+    headers: { accept: 'application/json' }
+  });
+
+  const body = await res.json().catch(() => ({ namespaces: [] }));
+  return json(body, { status: res.status });
+};

--- a/apps/web/src/routes/api/resources/+server.ts
+++ b/apps/web/src/routes/api/resources/+server.ts
@@ -1,0 +1,35 @@
+import { PUBLIC_ENGINE_HTTP_BASE } from '$env/static/public';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+  const cluster = url.searchParams.get('cluster') ?? '';
+  const kind = url.searchParams.get('kind') ?? '';
+  const namespace = url.searchParams.get('namespace') ?? undefined;
+
+  if (!cluster || !kind) return json({ items: [] }, { status: 400 });
+
+  if (!PUBLIC_ENGINE_HTTP_BASE) {
+    // Deterministic stub rows.
+    const items =
+      kind === 'Nodes'
+        ? [{ name: 'node-1', status: 'Ready', age: '1d' }]
+        : kind === 'Deployments'
+          ? [{ name: 'api', namespace: namespace ?? 'default', status: 'Available', age: '3h' }]
+          : [{ name: 'api-7d9', namespace: namespace ?? 'default', status: 'Running', age: '12m' }];
+
+    return json({ items }, { status: 200 });
+  }
+
+  const qs = new URLSearchParams();
+  qs.set('cluster', cluster);
+  qs.set('kind', kind);
+  if (namespace) qs.set('namespace', namespace);
+
+  const res = await fetch(`${PUBLIC_ENGINE_HTTP_BASE}/api/resources?${qs.toString()}`, {
+    headers: { accept: 'application/json' }
+  });
+
+  const body = await res.json().catch(() => ({ items: [] }));
+  return json(body, { status: res.status });
+};

--- a/apps/web/src/routes/explore/+page.svelte
+++ b/apps/web/src/routes/explore/+page.svelte
@@ -1,15 +1,165 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import ContextBanner from '$lib/components/ContextBanner.svelte';
+  import type { Cluster, Kind, Namespace, ResourceRow } from '$lib/engine';
 
-  $: cluster = $page.url.searchParams.get('cluster');
+  export let data: {
+    clusterId: string;
+    namespace: string;
+    kind: string;
+    clusters: Cluster[];
+    kinds: Kind[];
+    namespaces: Namespace[];
+    items: ResourceRow[];
+  };
+
+  const selectKind = (k: string) => {
+    const u = new URL(window.location.href);
+    u.searchParams.set('kind', k);
+    window.location.assign(u);
+  };
 </script>
 
 <h1>Explore</h1>
 
-{#if cluster}
-  <p>
-    Cluster: <strong data-testid="selected-cluster">{cluster}</strong>
-  </p>
-{:else}
-  <p role="alert">No cluster selected.</p>
-{/if}
+<ContextBanner
+  clusterId={data.clusterId}
+  clusters={data.clusters}
+  namespaces={data.namespaces}
+  namespace={data.namespace}
+/>
+
+<div class="layout">
+  <aside class="sidebar">
+    <h2>Kinds</h2>
+    <ul>
+      {#each data.kinds as k}
+        <li>
+          <button
+            class:selected={k.kind === data.kind}
+            data-testid={`kind-${k.kind}`}
+            on:click={() => selectKind(k.kind)}
+          >
+            {k.kind}
+            {#if !k.namespaced}
+              <span class="pill">cluster</span>
+            {/if}
+          </button>
+        </li>
+      {/each}
+    </ul>
+  </aside>
+
+  <main class="main">
+    <div class="toolbar">
+      <div class="title">{data.kind}</div>
+      <div class="meta" data-testid="selected-cluster">{data.clusterId}</div>
+    </div>
+
+    {#if data.items.length === 0}
+      <p class="empty">No resources found.</p>
+    {:else}
+      <table class="table" data-testid="resource-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Namespace</th>
+            <th>Status</th>
+            <th>Age</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each data.items as r}
+            <tr>
+              <td>{r.name}</td>
+              <td>{r.namespace ?? '-'}</td>
+              <td>{r.status ?? '-'}</td>
+              <td>{r.age ?? '-'}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </main>
+</div>
+
+<style>
+  .layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .sidebar {
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    padding: 10px;
+    background: #0e0e0e;
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 6px;
+  }
+  button {
+    width: 100%;
+    text-align: left;
+    padding: 8px;
+    border-radius: 8px;
+    border: 1px solid #2a2a2a;
+    background: #111;
+    color: #eee;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+  }
+  button.selected {
+    border-color: #5b8cff;
+  }
+  .pill {
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    border: 1px solid #333;
+    color: #bbb;
+  }
+  .main {
+    border: 1px solid #2a2a2a;
+    border-radius: 8px;
+    padding: 10px;
+    background: #0e0e0e;
+    overflow: hidden;
+  }
+  .toolbar {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+  .title {
+    font-weight: 700;
+  }
+  .meta {
+    font-size: 12px;
+    color: #999;
+  }
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th,
+  td {
+    border-bottom: 1px solid #222;
+    padding: 8px;
+  }
+  th {
+    text-align: left;
+    color: #bbb;
+    font-weight: 600;
+  }
+  .empty {
+    color: #aaa;
+  }
+</style>

--- a/apps/web/src/routes/explore/+page.ts
+++ b/apps/web/src/routes/explore/+page.ts
@@ -1,0 +1,23 @@
+import { redirect } from '@sveltejs/kit';
+import { listClusters, listKinds, listNamespaces, listResources } from '$lib/engine';
+
+export const load = async ({ url, fetch }) => {
+  const clusterId = url.searchParams.get('cluster');
+  if (!clusterId) throw redirect(302, '/clusters');
+
+  const namespace = url.searchParams.get('namespace') ?? 'default';
+  const kind = url.searchParams.get('kind') ?? 'Pods';
+
+  const [clusters, kinds, namespaces] = await Promise.all([
+    listClusters(fetch),
+    listKinds(fetch),
+    listNamespaces(fetch, clusterId)
+  ]);
+
+  const kindMeta = kinds.find((k) => k.kind === kind) ?? { kind, namespaced: true };
+  const effectiveNamespace = kindMeta.namespaced ? namespace : undefined;
+
+  const items = await listResources(fetch, { clusterId, namespace: effectiveNamespace, kind });
+
+  return { clusterId, namespace, kind, clusters, kinds, namespaces, items };
+};

--- a/apps/web/tests-e2e/explore.spec.ts
+++ b/apps/web/tests-e2e/explore.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('explore: banner shows cluster + namespace, kind switch updates list', async ({ page }) => {
+  await page.goto('/clusters');
+  await page.getByRole('button', { name: /Local Dev Cluster \(local-dev\)/ }).click();
+
+  await expect(page).toHaveURL(/\/explore\?cluster=local-dev/);
+
+  // Banner
+  await expect(page.getByTestId('context-banner')).toBeVisible();
+  await expect(page.getByTestId('cluster-name')).toContainText('Local Dev Cluster');
+
+  // Namespace default
+  await expect(page.getByTestId('namespace-select')).toHaveValue('default');
+
+  // Switch kind
+  await page.getByTestId('kind-Nodes').click();
+  await expect(page.getByRole('heading', { name: 'Explore' })).toBeVisible();
+  await expect(page.getByTestId('resource-table')).toBeVisible();
+  await expect(page.getByText('node-1')).toBeVisible();
+});

--- a/apps/web/tests-e2e/stub/stub-server.mjs
+++ b/apps/web/tests-e2e/stub/stub-server.mjs
@@ -41,6 +41,39 @@ const server = http.createServer(async (req, res) => {
       return json(res, 200, fixture);
     }
 
+    // M1 explorer endpoints (deterministic)
+    if (req.method === 'GET' && url.pathname === '/api/kinds') {
+      return json(res, 200, {
+        kinds: [
+          { kind: 'Pods', namespaced: true },
+          { kind: 'Deployments', namespaced: true },
+          { kind: 'Services', namespaced: true },
+          { kind: 'ConfigMaps', namespaced: true },
+          { kind: 'Nodes', namespaced: false },
+          { kind: 'Namespaces', namespaced: false }
+        ]
+      });
+    }
+
+    const nsMatch = url.pathname.match(/^\/api\/clusters\/([^/]+)\/namespaces$/);
+    if (req.method === 'GET' && nsMatch) {
+      return json(res, 200, { namespaces: [{ name: 'default' }, { name: 'kube-system' }] });
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/resources') {
+      const kind = url.searchParams.get('kind') ?? '';
+      const namespace = url.searchParams.get('namespace') ?? 'default';
+
+      const items =
+        kind === 'Nodes'
+          ? [{ name: 'node-1', status: 'Ready', age: '1d' }]
+          : kind === 'Deployments'
+            ? [{ name: 'api', namespace, status: 'Available', age: '3h' }]
+            : [{ name: 'api-7d9', namespace, status: 'Running', age: '12m' }];
+
+      return json(res, 200, { items });
+    }
+
     return text(res, 404, 'not found');
   } catch (err) {
     return text(res, 500, `stub server error: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/dev-test.sh
+++ b/scripts/dev-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 IMAGE=telescope-devtest:local
 
 # Build a deterministic dev test container with Rust + Node + Playwright deps.
-docker build -f tools/devtest/Dockerfile -t "$IMAGE" .
+docker build --pull=false -f tools/devtest/Dockerfile -t "$IMAGE" .
 
 # Run tests inside container. We mount repo at /repo.
 docker run --rm -t \

--- a/scripts/pnpm.sh
+++ b/scripts/pnpm.sh
@@ -7,8 +7,12 @@ set -euo pipefail
 PNPM_CJS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.corepack/v1/pnpm/9.15.4/bin/pnpm.cjs"
 
 if [[ ! -f "$PNPM_CJS" ]]; then
-  echo "pnpm not prepared. Run: COREPACK_HOME=./.corepack corepack prepare pnpm@9.15.4 --activate" >&2
-  exit 1
+  # Auto-prepare pnpm into the repo-local Corepack home (works in CI and dev containers).
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  export COREPACK_HOME="$REPO_ROOT/.corepack"
+
+  # corepack is shipped with Node; don't require global pnpm.
+  corepack prepare pnpm@9.15.4 --activate >/dev/null
 fi
 
 exec node "$PNPM_CJS" "$@"


### PR DESCRIPTION
Implements M1 issues #15 and #16.

Adds:
- Web: Context/Namespace banner component
- /explore page shell with kinds sidebar and resources table
- New internal API routes: /api/namespaces, /api/kinds, /api/resources (deterministic stub or proxy via PUBLIC_ENGINE_HTTP_BASE)
- Stub engine server updated to serve the new endpoints for Playwright
- E2E: explore.spec.ts (banner + kind switch)
- Ops: pnpm.sh auto-prepares pnpm via corepack; dev-test.sh uses --pull=false for offline/cached builds

Validation:
- ./scripts/dev-test.sh (container) passes