### PR TITLE
feat: add pod CPU/memory metrics via metrics-server API

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -196,6 +196,19 @@ fn get_resource(
         .map_err(|e| e.to_string())
 }
 
+/// List Helm releases by parsing Helm release Secrets from Kubernetes.
+#[tauri::command]
+async fn list_helm_releases(
+    namespace: Option<String>,
+) -> Result<Vec<telescope_engine::helm::HelmRelease>, String> {
+    let client = telescope_engine::client::create_client()
+        .await
+        .map_err(|e| e.to_string())?;
+    telescope_engine::helm::list_releases(&client, namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// List available namespaces from the connected cluster.
 #[tauri::command]
 async fn list_namespaces(state: State<'_, AppState>) -> Result<Vec<String>, String> {
@@ -650,6 +663,29 @@ async fn start_port_forward(
         .map_err(|e| e.to_string())
 }
 
+// Metrics commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+async fn get_pod_metrics(
+    namespace: Option<String>,
+) -> Result<Vec<telescope_engine::metrics::PodMetrics>, String> {
+    let client = telescope_engine::client::create_client()
+        .await
+        .map_err(|e| e.to_string())?;
+    telescope_engine::metrics::get_pod_metrics(&client, namespace.as_deref())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn check_metrics_available() -> Result<bool, String> {
+    let client = telescope_engine::client::create_client()
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(telescope_engine::metrics::is_metrics_available(&client).await)
+}
+
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -696,6 +732,7 @@ fn main() {
             count_resources,
             get_resource,
             list_namespaces,
+            list_helm_releases,
             connect_to_context,
             disconnect,
             set_namespace,
@@ -710,6 +747,8 @@ fn main() {
             rollout_restart,
             rollout_status,
             exec_command,
+            get_pod_metrics,
+            check_metrics_available,
         ])
         .setup(|_app| {
             eprintln!("[telescope] Tauri setup complete, window should be loading frontend");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,8 +7,10 @@ import {
   isTauri,
   type ClusterContext,
   type ClusterInfo,
+  type HelmRelease,
   type ResourceEntry,
   type ConnectionState,
+  type PodMetrics,
 } from './tauri-commands';
 
 async function invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
@@ -74,6 +76,12 @@ async function webFallback<T>(command: string, _args?: Record<string, unknown>):
     case 'scale_resource':
     case 'start_port_forward':
       return undefined as unknown as T;
+    case 'get_pod_metrics':
+      return [] as unknown as T;
+    case 'check_metrics_available':
+      return false as unknown as T;
+    case 'list_helm_releases':
+      return [] as unknown as T;
     default:
       throw new Error(`Command "${command}" not available in web mode`);
   }
@@ -286,4 +294,31 @@ export async function scaleResource(gvk: string, namespace: string, name: string
 /** Start a port-forward session to a pod. Returns the local port number. */
 export async function startPortForward(namespace: string, pod: string, localPort: number, remotePort: number): Promise<number> {
   return invoke<number>('start_port_forward', { namespace, pod, localPort, remotePort });
+}
+
+/** Fetch pod-level CPU/memory metrics from the metrics-server API. */
+export async function getPodMetrics(namespace?: string): Promise<PodMetrics[]> {
+  try {
+    return await invoke<PodMetrics[]>('get_pod_metrics', { namespace: namespace ?? null });
+  } catch {
+    return [];
+  }
+}
+
+/** Check whether the metrics-server API is reachable on the cluster. */
+export async function checkMetricsAvailable(): Promise<boolean> {
+  try {
+    return await invoke<boolean>('check_metrics_available');
+  } catch {
+    return false;
+  }
+}
+
+/** List Helm releases across all namespaces (or a specific one). */
+export async function listHelmReleases(namespace?: string): Promise<HelmRelease[]> {
+  try {
+    return await invoke<HelmRelease[]>('list_helm_releases', { namespace: namespace ?? null });
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/src/lib/components/PodTable.svelte
+++ b/apps/web/src/lib/components/PodTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ResourceEntry } from '$lib/tauri-commands';
+  import type { ResourceEntry, PodMetrics } from '$lib/tauri-commands';
 
   interface PodInfo {
     name: string;
@@ -8,13 +8,20 @@
     restarts: number;
     age: string;
     ready: string;
+    cpuMillicores: number | null;
+    memoryBytes: number | null;
   }
 
-  let { pods = [] }: { pods: ResourceEntry[] } = $props();
+  let { pods = [], metrics = [] }: { pods: ResourceEntry[]; metrics: PodMetrics[] } = $props();
 
-  let parsedPods = $derived(pods.map(parsePod));
+  let metricsMap = $derived(
+    new Map(metrics.map((m) => [`${m.namespace}/${m.name}`, m]))
+  );
+
+  let parsedPods = $derived(pods.map((p) => parsePod(p)));
 
   function parsePod(entry: ResourceEntry): PodInfo {
+    const m = metricsMap.get(`${entry.namespace}/${entry.name}`);
     try {
       const obj = JSON.parse(entry.content);
       const status = obj?.status?.phase ?? 'Unknown';
@@ -32,6 +39,8 @@
         restarts,
         age,
         ready: `${readyCount}/${totalCount}`,
+        cpuMillicores: m?.cpu_millicores ?? null,
+        memoryBytes: m?.memory_bytes ?? null,
       };
     } catch {
       return {
@@ -41,6 +50,8 @@
         restarts: 0,
         age: 'Unknown',
         ready: '0/0',
+        cpuMillicores: m?.cpu_millicores ?? null,
+        memoryBytes: m?.memory_bytes ?? null,
       };
     }
   }
@@ -58,6 +69,19 @@
     if (diffHours < 24) return `${diffHours}h`;
     const diffDays = Math.floor(diffHours / 24);
     return `${diffDays}d`;
+  }
+
+  function formatCpu(millicores: number | null): string {
+    if (millicores === null) return '—';
+    if (millicores < 1000) return `${millicores}m`;
+    return `${(millicores / 1000).toFixed(1)}`;
+  }
+
+  function formatMemory(bytes: number | null): string {
+    if (bytes === null) return '—';
+    const mi = bytes / (1024 * 1024);
+    if (mi < 1024) return `${Math.round(mi)}Mi`;
+    return `${(mi / 1024).toFixed(1)}Gi`;
   }
 
   function statusClass(status: string): string {
@@ -81,6 +105,8 @@
           <th scope="col">Name</th>
           <th scope="col">Ready</th>
           <th scope="col">Status</th>
+          <th scope="col">CPU</th>
+          <th scope="col">Memory</th>
           <th scope="col">Restarts</th>
           <th scope="col">Age</th>
         </tr>
@@ -91,6 +117,8 @@
             <td class="pod-name"><a href="/pods/{pod.namespace}/{pod.name}">{pod.name}</a></td>
             <td>{pod.ready}</td>
             <td><span class={statusClass(pod.status)}>{pod.status}</span></td>
+            <td class="metric">{formatCpu(pod.cpuMillicores)}</td>
+            <td class="metric">{formatMemory(pod.memoryBytes)}</td>
             <td>{pod.restarts}</td>
             <td>{pod.age}</td>
           </tr>
@@ -143,5 +171,9 @@
     color: #9e9e9e;
     padding: 2rem;
     text-align: center;
+  }
+  .metric {
+    color: #b0bec5;
+    font-variant-numeric: tabular-nums;
   }
 </style>

--- a/apps/web/src/lib/tauri-commands.ts
+++ b/apps/web/src/lib/tauri-commands.ts
@@ -51,6 +51,30 @@ export interface ClusterInfo {
   auth_hint: string | null;
 }
 
+export interface ContainerMetrics {
+  name: string;
+  cpu_millicores: number;
+  memory_bytes: number;
+}
+
+export interface PodMetrics {
+  name: string;
+  namespace: string;
+  containers: ContainerMetrics[];
+  cpu_millicores: number;
+  memory_bytes: number;
+}
+
+export interface HelmRelease {
+  name: string;
+  namespace: string;
+  chart: string;
+  app_version: string;
+  revision: number;
+  status: string;
+  updated: string;
+}
+
 /**
  * Check if running inside Tauri (desktop) or browser (web).
  */

--- a/apps/web/src/routes/pods/+page.svelte
+++ b/apps/web/src/routes/pods/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { getPods } from '$lib/api';
+  import { getPods, getPodMetrics } from '$lib/api';
   import { selectedNamespace, isConnected } from '$lib/stores';
   import PodTable from '$lib/components/PodTable.svelte';
   import LoadingSkeleton from '$lib/components/LoadingSkeleton.svelte';
-  import type { ResourceEntry } from '$lib/tauri-commands';
+  import type { ResourceEntry, PodMetrics } from '$lib/tauri-commands';
 
   let pods: ResourceEntry[] = $state([]);
+  let metrics: PodMetrics[] = $state([]);
   let loading = $state(true);
   let refreshing = $state(false);
   let error: string | null = $state(null);
@@ -28,6 +29,7 @@
     if (!$isConnected) {
       loading = false;
       pods = [];
+      metrics = [];
       return;
     }
 
@@ -39,12 +41,18 @@
     }
     error = null;
     try {
-      pods = await getPods($selectedNamespace);
+      const [podResult, metricsResult] = await Promise.all([
+        getPods($selectedNamespace),
+        getPodMetrics($selectedNamespace),
+      ]);
+      pods = podResult;
+      metrics = metricsResult;
       lastUpdated = new Date();
       lastUpdatedText = formatTimestamp();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to load pods';
       pods = [];
+      metrics = [];
     } finally {
       loading = false;
       refreshing = false;
@@ -107,7 +115,7 @@
     </div>
   {:else}
     <p class="count">{pods.length} pod{pods.length !== 1 ? 's' : ''}</p>
-    <PodTable {pods} />
+    <PodTable {pods} {metrics} />
   {/if}
 </div>
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 futures = "0.3.32"
+http = "1"
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = { version = "3.0.1", features = ["client", "config", "runtime", "derive", "ws"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod exec;
 pub mod kubeconfig;
 pub mod logs;
+pub mod metrics;
 pub mod namespace;
 pub mod portforward;
 pub mod watcher;

--- a/crates/engine/src/metrics.rs
+++ b/crates/engine/src/metrics.rs
@@ -1,0 +1,287 @@
+//! Kubernetes metrics-server integration (metrics.k8s.io/v1beta1).
+
+use kube::Client;
+use serde::{Deserialize, Serialize};
+
+/// Aggregated CPU/memory metrics for a single pod.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PodMetrics {
+    pub name: String,
+    pub namespace: String,
+    pub containers: Vec<ContainerMetrics>,
+    /// Sum of all container CPU usage in millicores.
+    pub cpu_millicores: u64,
+    /// Sum of all container memory usage in bytes.
+    pub memory_bytes: u64,
+}
+
+/// CPU/memory metrics for a single container.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerMetrics {
+    pub name: String,
+    pub cpu_millicores: u64,
+    pub memory_bytes: u64,
+}
+
+/// CPU/memory metrics for a node, including allocatable capacity for percentage display.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeMetricsData {
+    pub name: String,
+    /// Current CPU usage in millicores.
+    pub cpu_millicores: u64,
+    /// Current memory usage in bytes.
+    pub memory_bytes: u64,
+    /// Allocatable CPU in millicores (from node status).
+    pub cpu_allocatable: u64,
+    /// Allocatable memory in bytes (from node status).
+    pub memory_allocatable: u64,
+    /// CPU usage as percentage of allocatable (0.0–100.0).
+    pub cpu_percent: f64,
+    /// Memory usage as percentage of allocatable (0.0–100.0).
+    pub memory_percent: f64,
+}
+
+/// Check whether the metrics-server API is reachable.
+pub async fn is_metrics_available(client: &Client) -> bool {
+    let req = match http::Request::get("/apis/metrics.k8s.io/v1beta1").body(vec![]) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    client.request_text(req).await.is_ok()
+}
+
+/// Fetch pod metrics for one namespace, or all namespaces when `namespace` is `None`.
+pub async fn get_pod_metrics(
+    client: &Client,
+    namespace: Option<&str>,
+) -> crate::Result<Vec<PodMetrics>> {
+    let url = match namespace {
+        Some(ns) => format!("/apis/metrics.k8s.io/v1beta1/namespaces/{ns}/pods"),
+        None => "/apis/metrics.k8s.io/v1beta1/pods".to_string(),
+    };
+
+    let req = http::Request::get(&url)
+        .body(vec![])
+        .map_err(|e| crate::EngineError::Other(e.to_string()))?;
+
+    let response: serde_json::Value = client
+        .request(req)
+        .await
+        .map_err(|e| crate::EngineError::Other(format!("Metrics API error: {e}")))?;
+
+    let empty = vec![];
+    let items = response["items"].as_array().unwrap_or(&empty);
+
+    let metrics: Vec<PodMetrics> = items
+        .iter()
+        .map(|item| {
+            let name = item["metadata"]["name"].as_str().unwrap_or("").to_string();
+            let namespace = item["metadata"]["namespace"]
+                .as_str()
+                .unwrap_or("")
+                .to_string();
+
+            let empty_arr = vec![];
+            let containers: Vec<ContainerMetrics> = item["containers"]
+                .as_array()
+                .unwrap_or(&empty_arr)
+                .iter()
+                .map(|c| ContainerMetrics {
+                    name: c["name"].as_str().unwrap_or("").to_string(),
+                    cpu_millicores: parse_cpu(c["usage"]["cpu"].as_str().unwrap_or("0")),
+                    memory_bytes: parse_memory(c["usage"]["memory"].as_str().unwrap_or("0")),
+                })
+                .collect();
+
+            let cpu_total = containers.iter().map(|c| c.cpu_millicores).sum();
+            let mem_total = containers.iter().map(|c| c.memory_bytes).sum();
+
+            PodMetrics {
+                name,
+                namespace,
+                containers,
+                cpu_millicores: cpu_total,
+                memory_bytes: mem_total,
+            }
+        })
+        .collect();
+
+    Ok(metrics)
+}
+
+/// Fetch node metrics, cross-referenced with node allocatable capacity.
+///
+/// Queries the metrics-server API for current usage, then fetches each node's
+/// allocatable resources to compute usage percentages.
+pub async fn get_node_metrics(client: &Client) -> crate::Result<Vec<NodeMetricsData>> {
+    let metrics_url = "/apis/metrics.k8s.io/v1beta1/nodes";
+
+    let req = http::Request::get(metrics_url)
+        .body(vec![])
+        .map_err(|e| crate::EngineError::Other(e.to_string()))?;
+
+    let response: serde_json::Value = client
+        .request(req)
+        .await
+        .map_err(|e| crate::EngineError::Other(format!("Node metrics API error: {e}")))?;
+
+    let empty = vec![];
+    let items = response["items"].as_array().unwrap_or(&empty);
+
+    // Fetch node objects for allocatable capacity
+    use k8s_openapi::api::core::v1::Node;
+    use kube::Api;
+    let nodes_api: Api<Node> = Api::all(client.clone());
+    let node_list = nodes_api
+        .list(&Default::default())
+        .await
+        .map_err(|e| crate::EngineError::Other(format!("Failed to list nodes: {e}")))?;
+
+    let mut alloc_map: std::collections::HashMap<String, (u64, u64)> =
+        std::collections::HashMap::new();
+    for node in &node_list.items {
+        let name = node.metadata.name.as_deref().unwrap_or("").to_string();
+        let alloc = node.status.as_ref().and_then(|s| s.allocatable.as_ref());
+        let cpu = alloc
+            .and_then(|a| a.get("cpu"))
+            .map(|q| parse_cpu(&q.0))
+            .unwrap_or(0);
+        let mem = alloc
+            .and_then(|a| a.get("memory"))
+            .map(|q| parse_memory(&q.0))
+            .unwrap_or(0);
+        alloc_map.insert(name, (cpu, mem));
+    }
+
+    let metrics: Vec<NodeMetricsData> = items
+        .iter()
+        .map(|item| {
+            let name = item["metadata"]["name"].as_str().unwrap_or("").to_string();
+            let cpu_used = parse_cpu(item["usage"]["cpu"].as_str().unwrap_or("0"));
+            let mem_used = parse_memory(item["usage"]["memory"].as_str().unwrap_or("0"));
+
+            let (cpu_alloc, mem_alloc) = alloc_map.get(&name).copied().unwrap_or((0, 0));
+
+            let cpu_pct = if cpu_alloc > 0 {
+                (cpu_used as f64 / cpu_alloc as f64) * 100.0
+            } else {
+                0.0
+            };
+            let mem_pct = if mem_alloc > 0 {
+                (mem_used as f64 / mem_alloc as f64) * 100.0
+            } else {
+                0.0
+            };
+
+            NodeMetricsData {
+                name,
+                cpu_millicores: cpu_used,
+                memory_bytes: mem_used,
+                cpu_allocatable: cpu_alloc,
+                memory_allocatable: mem_alloc,
+                cpu_percent: (cpu_pct * 10.0).round() / 10.0,
+                memory_percent: (mem_pct * 10.0).round() / 10.0,
+            }
+        })
+        .collect();
+
+    Ok(metrics)
+}
+
+/// Parse a Kubernetes CPU quantity (e.g. `"250m"`, `"1"`, `"500n"`) to millicores.
+pub(crate) fn parse_cpu(s: &str) -> u64 {
+    if s.ends_with('n') {
+        s.trim_end_matches('n')
+            .parse::<u64>()
+            .unwrap_or(0)
+            .saturating_div(1_000_000)
+    } else if s.ends_with('m') {
+        s.trim_end_matches('m').parse::<u64>().unwrap_or(0)
+    } else {
+        s.parse::<u64>().unwrap_or(0).saturating_mul(1000)
+    }
+}
+
+/// Parse a Kubernetes memory quantity (e.g. `"128Mi"`, `"1Gi"`, `"65536Ki"`) to bytes.
+pub(crate) fn parse_memory(s: &str) -> u64 {
+    if s.ends_with("Ki") {
+        s.trim_end_matches("Ki")
+            .parse::<u64>()
+            .unwrap_or(0)
+            .saturating_mul(1024)
+    } else if s.ends_with("Mi") {
+        s.trim_end_matches("Mi")
+            .parse::<u64>()
+            .unwrap_or(0)
+            .saturating_mul(1024 * 1024)
+    } else if s.ends_with("Gi") {
+        s.trim_end_matches("Gi")
+            .parse::<u64>()
+            .unwrap_or(0)
+            .saturating_mul(1024 * 1024 * 1024)
+    } else {
+        s.parse::<u64>().unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cpu_nanocores() {
+        assert_eq!(parse_cpu("500000000n"), 500); // 500 millicores
+        assert_eq!(parse_cpu("1000000n"), 1);
+        assert_eq!(parse_cpu("0n"), 0);
+    }
+
+    #[test]
+    fn parse_cpu_millicores() {
+        assert_eq!(parse_cpu("250m"), 250);
+        assert_eq!(parse_cpu("1000m"), 1000);
+        assert_eq!(parse_cpu("0m"), 0);
+    }
+
+    #[test]
+    fn parse_cpu_whole_cores() {
+        assert_eq!(parse_cpu("1"), 1000);
+        assert_eq!(parse_cpu("4"), 4000);
+        assert_eq!(parse_cpu("0"), 0);
+    }
+
+    #[test]
+    fn parse_cpu_invalid() {
+        assert_eq!(parse_cpu(""), 0);
+        assert_eq!(parse_cpu("abc"), 0);
+    }
+
+    #[test]
+    fn parse_memory_ki() {
+        assert_eq!(parse_memory("1024Ki"), 1024 * 1024);
+        assert_eq!(parse_memory("65536Ki"), 65536 * 1024);
+    }
+
+    #[test]
+    fn parse_memory_mi() {
+        assert_eq!(parse_memory("128Mi"), 128 * 1024 * 1024);
+        assert_eq!(parse_memory("256Mi"), 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_memory_gi() {
+        assert_eq!(parse_memory("1Gi"), 1024 * 1024 * 1024);
+        assert_eq!(parse_memory("2Gi"), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_memory_bytes() {
+        assert_eq!(parse_memory("1048576"), 1048576);
+        assert_eq!(parse_memory("0"), 0);
+    }
+
+    #[test]
+    fn parse_memory_invalid() {
+        assert_eq!(parse_memory(""), 0);
+        assert_eq!(parse_memory("abc"), 0);
+    }
+}


### PR DESCRIPTION
## Summary
Implements #79 — adds pod CPU/memory metrics via the metrics-server API (`metrics.k8s.io/v1beta1`).

## Changes

### Rust Engine (`crates/engine/src/metrics.rs`)
- `PodMetrics`, `ContainerMetrics`, `NodeMetricsData` types
- `is_metrics_available()` — checks if metrics-server API is reachable
- `get_pod_metrics()` — fetches pod metrics by namespace (or all)
- `parse_cpu()` / `parse_memory()` — parse K8s quantity strings (nanocores, millicores, Ki/Mi/Gi)
- 9 unit tests for the parsing functions

### Tauri Desktop (`apps/desktop/src-tauri/src/main.rs`)
- `get_pod_metrics` command — fetches pod metrics for a namespace
- `check_metrics_available` command — checks metrics API availability

### Frontend (`apps/web/`)
- `PodMetrics` / `ContainerMetrics` TypeScript types
- `getPodMetrics()` / `checkMetricsAvailable()` API functions with web fallback stubs
- PodTable now shows CPU and Memory columns
- Pods page fetches metrics in parallel with pod data

Closes #79