### PR TITLE
security: architectural hardening and vulnerability remediation (Sprint 2026-05-10)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+    open-pull-requests-limit: 5
+    groups:
+      pnpm-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -6,6 +6,8 @@
 
 **Primary workflow:** `ci.yml` — runs on all PRs and pushes to `main`.
 
+**Integration workflow:** `integration.yml` — runs K3D engine integration tests on manual dispatch, pushes to `main`, and PRs touching engine, core, K3D fixture, or integration workflow paths.
+
 **Release workflow:** `release.yml` — runs on pushed Git tags matching `v*`.
 
 ## Current CI Jobs (`ci.yml`)
@@ -22,7 +24,20 @@ cargo test --workspace --exclude telescope-desktop --all-features
 
 `telescope-desktop` is excluded on Linux (GTK/WebKit system deps). Desktop builds run separately on Windows/macOS.
 
-### 2. Web Job (`web`)
+### 2. Security Job (`security`)
+
+Runs on: `ubuntu-latest`
+
+```bash
+cargo install cargo-audit --locked
+cargo audit
+pnpm install --frozen-lockfile
+pnpm audit --audit-level high
+```
+
+This job runs on pull requests and pushes alongside the build/test jobs. Dependabot is configured in `.github/dependabot.yml` for weekly Cargo and npm/pnpm workspace dependency updates.
+
+### 3. Web Job (`web`)
 
 Runs on: `ubuntu-latest`
 
@@ -32,7 +47,7 @@ pnpm -C apps/web test      # Vitest unit tests
 pnpm -C apps/web build     # Production build
 ```
 
-### 3. Web E2E Job (`web-e2e`)
+### 4. Web E2E Job (`web-e2e`)
 
 Runs on: `ubuntu-latest` (depends on `web` job)
 
@@ -44,7 +59,7 @@ pnpm -C apps/web e2e       # Playwright tests against stub server
 
 E2E tests run against `tools/devtest/stub-server.mjs` with deterministic fake data (no live K8s cluster).
 
-### 4. Desktop Build Job (`desktop-build`)
+### 5. Desktop Build Job (`desktop-build`)
 
 Runs on: **Matrix** — `[windows-latest, macos-latest]`
 
@@ -94,9 +109,10 @@ Steps:
 | Web unit tests | [ok] | Vitest via `pnpm -C apps/web test` |
 | Web build | [ok] | `pnpm -C apps/web build` |
 | Web E2E tests | [ok] | Playwright against stub server |
+| K3D integration tests | [ok] | `integration.yml` is PR-gated for engine/core/K3D fixture/workflow paths |
 | Desktop builds | [ok] | Windows + macOS matrix |
 | Tagged releases | [ok] | `release.yml` on `v*` tags |
-| Security scanning | [fail] | No Dependabot, CodeQL, or audit checks |
+| Security scanning | [ok] | Dependabot plus CI `cargo audit` and `pnpm audit --audit-level high` |
 
 ## Concurrency
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,27 @@ jobs:
       - name: Cargo test
         run: cargo test --workspace --exclude telescope-desktop --all-features
 
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Rust dependency audit
+        run: cargo audit
+      - name: Install pnpm dependencies
+        run: pnpm install --frozen-lockfile
+      - name: pnpm dependency audit
+        run: pnpm audit --audit-level high
+
   web:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,12 @@ on:
       - 'crates/core/**'
       - 'tools/k3d-fixtures/**'
       - '.github/workflows/integration.yml'
+  pull_request:
+    paths:
+      - 'crates/engine/**'
+      - 'crates/core/**'
+      - 'tools/k3d-fixtures/**'
+      - '.github/workflows/integration.yml'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ GitHub releases use the matching version section from this changelog when presen
 
 ## [Unreleased]
 
+### Added
+- **Supply chain scanning:** Added CI security checks for Rust and pnpm dependencies, including `cargo audit`, `pnpm audit --audit-level high`, and grouped weekly Dependabot update coverage.
+- **GVK allowlist validation:** Cached resource IPC commands now validate caller-provided GVKs against the watched resource registry before querying the SQLite cache.
+
+### Fixed
+- **Watcher task leaks:** Replaced the raw watch task handle with a supervisor owner that shares a `CancellationToken` across the state forwarder and all watcher tasks, with cancel/drop cleanup for reconnect, disconnect, namespace switch, and replacement paths.
+- **Trusted binary test fixtures and Azure resolver tests:** Reworked trusted helper fixtures so tests exercise the production hardening path without relying on group-writable Cargo test executables.
+- **Port-forward counter race conditions:** Added RAII accounting for active port-forwards so panic, abort, and early-return paths release concurrency slots reliably.
+
+### Security
+- **Sanitized command and API errors:** Helm command failures and frontend IPC errors now return user-safe categories without leaking helper paths, raw command output, local paths, or secret-shaped values.
+- **Denied and audited Helm values reveal:** Plaintext Helm values reveal requests are denied before values are fetched, logged as denied audit events, and returned as sanitized errors; normal values requests remain recursively redacted.
+- **Trusted helper hardening:** Preserved strict trusted-binary resolution and permission checks for kubeconfig exec helpers, Azure CLI fallback, and Helm operations while improving fixture coverage.
+
 ## [v1.2.0] - 2026-03-21
 
 ### Added

--- a/REMEDIATION_STATUS.md
+++ b/REMEDIATION_STATUS.md
@@ -1,0 +1,227 @@
+# Remediation Status
+
+## F-01 — Trusted Binary Resolver Test Fixture
+
+Status: Fixed
+
+Files changed:
+- `crates/core/src/trusted_binary.rs`
+- `crates/azure/src/resolve.rs`
+- `crates/engine/src/kubeconfig.rs`
+- `REMEDIATION_STATUS.md`
+
+Reproduction:
+- `cargo test -p telescope-azure resolve::tests::resolve_az_binary_path_accepts_trusted_binary_name -- --nocapture` previously failed because the test used Cargo's current test executable as the trusted binary fixture. In this environment that executable is group-writable, so the production trusted-binary permission check correctly rejected it.
+- `cargo test -p telescope-core trusted_binary::tests::resolve_trusted_binary_accepts_trusted_binary_name -- --nocapture` failed for the same fixture reason.
+- The final workspace test gate also exposed the same fixture problem in `crates/engine/src/kubeconfig.rs` exec-helper tests, which used `std::env::current_exe()` as a trusted kubeconfig helper.
+
+Remediation:
+- Replaced the affected `current_exe()` fixture seam with dedicated std-only temporary helper files in the Rust test modules.
+- Each fixture uses a unique temp-file name from `std::env::temp_dir()`, is made executable with Unix mode `0o755`, and is removed on drop.
+- Production trusted-binary validation and permission checks were not weakened.
+
+Verification:
+- Pass: `cargo test -p telescope-core trusted_binary::tests::resolve_trusted_binary_accepts_trusted_binary_name -- --nocapture`
+- Pass: `cargo test -p telescope-azure resolve::tests::resolve_az_binary_path_accepts_trusted_binary_name -- --nocapture`
+- Pass: `cargo test -p telescope-core trusted_binary::tests -- --nocapture`
+- Pass: `cargo test -p telescope-azure --lib`
+- Pass: `cargo fmt --all -- --check`
+- Pass: `cargo test -p telescope-engine kubeconfig::tests -- --nocapture`
+
+## F-02 — Watcher Lifecycle Auxiliary Task Leak
+
+Status: Fixed
+
+Files changed:
+- `apps/desktop/src-tauri/src/main.rs`
+- `apps/desktop/src-tauri/Cargo.toml`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Code inspection confirmed the pre-fix lifecycle shape in `spawn_watch_task`: `AppState` stored only the main pod watcher `JoinHandle<()>`, while the state forwarder and auxiliary watcher handles were captured inside that main task.
+- `abort_watch` externally aborted only the stored main handle on reconnect, disconnect, and namespace switch. Because aborting a Tokio task drops its future immediately, the cleanup tail inside the main task could be skipped and auxiliary watcher tasks could continue running.
+
+Remediation:
+- Replaced the stored watcher handle with a `WatchTaskHandle` owner that holds a `CancellationToken` and all spawned watcher/forwarder `JoinHandle<()>` values.
+- `WatchTaskHandle::cancel` and `Drop` both cancel the token and abort owned tasks, so reconnect, disconnect, namespace switch, and replacement drops cannot orphan auxiliary watchers.
+- Updated state forwarding, cluster-scoped watchers, namespaced watchers, and the pod watcher to observe the shared cancellation token with `tokio::select!`.
+- Added `tokio-util = { version = "0.7", features = ["rt"] }` to the desktop crate for `CancellationToken`.
+
+Verification:
+- Pass: `cargo fmt --all -- --check`
+- Follow-up: `pkg-config --modversion glib-2.0` now resolves `2.80.0` on this host.
+- Host-only status: `cargo check -p telescope-desktop` now advances past `glib-sys` and fails before checking project code because `gdk-sys` cannot find `gdk-3.0.pc` via `pkg-config`.
+- Pass in build container: `./scripts/dev-test.sh run bash -lc 'sudo chown -R pwuser:pwuser /home/pwuser/.cargo /home/pwuser/.rustup /home/pwuser/.local/share/pnpm/store && ./scripts/pnpm.sh -C apps/desktop prepare:frontend && cargo check -p telescope-desktop'`
+- Pass in build container: `./scripts/dev-test.sh run cargo build -p telescope-desktop`
+
+## F-03 — Helm Values Reveal Plaintext Secrets
+
+Status: Fixed
+
+Files changed:
+- `apps/desktop/src-tauri/src/main.rs`
+- `apps/web/src/lib/api.ts`
+- `apps/web/src/routes/helm/[namespace]/[name]/+page.svelte`
+- `apps/web/src/lib/api.test.ts`
+- `apps/web/tests-e2e/detail-reload.spec.ts`
+- `apps/web/tests-e2e/helpers/mock-tauri.ts`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Code inspection confirmed the pre-fix backend fetched Helm release values and returned them unredacted whenever `reveal: true` was supplied to `get_helm_release_values`.
+- The Helm detail page exposed a reveal button and confirmation dialog that called `getHelmReleaseValues(namespace, releaseName, true)`.
+- The backend had audit coverage for Helm rollback and uninstall, but no audit entry for Helm values reveal attempts.
+
+Remediation:
+- `get_helm_release_values` now validates namespace and release name before use, rejects `reveal: true` before creating a Kubernetes client or fetching Helm values, writes a denied audit entry for the reveal attempt, and returns only sanitized denial messages.
+- Normal `reveal: false` or omitted reveal behavior still fetches Helm values and redacts sensitive keys before returning YAML.
+- The frontend API wrapper no longer accepts or sends a reveal flag, and the Helm detail page no longer renders the reveal button, sensitive-values warning, hide button, or reveal confirmation dialog.
+- The Playwright mock now fails accidental reveal calls, and API/E2E coverage asserts the UI requests Helm values without a reveal flag.
+
+Verification:
+- Pass: `cargo fmt --all -- --check`
+- Pass: `./scripts/pnpm.sh -C apps/web test` (8 files, 66 tests)
+- Pass: `./scripts/pnpm.sh -C apps/web e2e -- detail-reload.spec.ts` (4 tests)
+
+## F-04 — Raw Command Errors and Paths
+
+Status: Fixed
+
+Files changed:
+- `crates/engine/src/helm.rs`
+- `apps/web/src/lib/api.ts`
+- `apps/web/src/lib/api.test.ts`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Code inspection confirmed pre-fix `rollback_release` and `helm_uninstall` returned errors containing `helm_binary.display()` plus raw Helm `stderr` or `stdout` details.
+- `map_helm_uninstall_error` appended raw command output to category messages, so local paths or command details could reach the desktop JSON response.
+- The frontend IPC wrapper logged raw `Error` objects in `invoke`, and `notifyApiError` logged raw message strings to the console.
+
+Remediation:
+- Helm rollback and uninstall now resolve and execute the CLI through sanitized public error paths that return category messages only: release not found, permission denied, operation timed out, command unavailable, or command failed.
+- The trusted Helm binary resolver and its tests remain intact; public CLI call sites wrap resolver/execute failures without exposing executable paths or resolver internals.
+- Frontend API error handling now converts thrown/listener messages through path and secret redaction before propagation, and console logging records only command-level failure markers without raw `Error` objects or raw messages.
+- Added Rust tests proving Helm rollback/uninstall errors omit the mock binary path and raw `stderr` path/secret details, plus frontend tests proving thrown errors, listeners, and console logs do not contain raw paths or secrets.
+
+Verification:
+- Pass: `cargo fmt --all -- --check`
+- Pass: `cargo test -p telescope-engine helm::tests -- --nocapture` (29 tests)
+- Pass: `./scripts/pnpm.sh -C apps/web test` (8 files, 67 tests)
+
+## F-05 — Port-forward Active Counter Panic/Abort Safety
+
+Status: Fixed
+
+Files changed:
+- `crates/engine/src/portforward.rs`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Code inspection confirmed pre-fix `start_port_forward` incremented `ACTIVE_FORWARDS` with `fetch_add`, manually decremented it on selected pod verification, bind, and address error paths, then decremented only at the normal end of the spawned forwarding task.
+- Because Tokio task abort drops the task future immediately, and panic unwinding may skip explicit tail cleanup when not modeled as ownership, the manual task-tail decrement could leave the active counter elevated and eventually deny new forwards.
+
+Remediation:
+- Added a private `ActiveForwardGuard` that acquires a slot with atomic `fetch_update`, refusing new forwards once `MAX_FORWARDS` is reached without incrementing and undoing.
+- Implemented `Drop` for the guard so every early return after acquisition releases the active slot automatically.
+- Moved the guard into the spawned forwarding task after pod verification and listener bind succeed, so normal completion, panic unwinding, and task abort/drop release the active counter through RAII.
+- Added focused unit tests for guard acquire/drop accounting and at-limit rejection without requiring a Kubernetes cluster.
+
+Verification:
+- Pass: `cargo fmt --all -- --check`
+- Pass: `cargo test -p telescope-engine portforward -- --nocapture` (7 unit tests passed; integration filter ran 0 tests in this environment)
+
+## F-06 — Security and Supply-chain Scanning Absent from Workflows
+
+Status: Fixed
+
+Files changed:
+- `.github/workflows/ci.yml`
+- `.github/dependabot.yml`
+- `.github/workflows/AGENTS.md`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Confirmed pre-fix `.github/dependabot.yml` was missing.
+- `grep -RInE "cargo audit|cargo-audit|cargo deny|cargo-deny|pnpm audit|npm audit|codeql|trivy|osv|ossf|scorecard|security scan|supply-chain|dependency review|audit-ci" .github scripts package.json Cargo.toml pnpm-lock.yaml` produced no matches, confirming no existing Cargo audit, cargo-deny, pnpm audit, CodeQL, or equivalent security scan in CI/scripts.
+- `.github/workflows/AGENTS.md` explicitly marked security scanning as failed because Dependabot, CodeQL, and audit checks were absent.
+
+Remediation:
+- Added a dedicated `security` job to `.github/workflows/ci.yml` that runs on the existing pull request and `main` push triggers alongside current jobs.
+- The job installs `cargo-audit`, runs `cargo audit` against the committed Cargo lockfile, installs pnpm dependencies with `pnpm install --frozen-lockfile`, and runs `pnpm audit --audit-level high`.
+- Added `.github/dependabot.yml` with weekly grouped Cargo and npm/pnpm workspace dependency update checks.
+- Updated `.github/workflows/AGENTS.md` to document the new security job and mark security scanning as enforced.
+
+Verification:
+- Pass: `git diff --check`
+- Pass: no-network YAML indentation sanity check of `.github/workflows/ci.yml` and `.github/dependabot.yml` with Node
+- Not run locally: `cargo audit` and `pnpm audit --audit-level high`; both require installing/downloading tools or querying external advisory/package registries. These gates now execute in CI.
+
+## F-07 — K3D Integration Tests Not PR-gated
+
+Status: Fixed
+
+Files changed:
+- `.github/workflows/integration.yml`
+- `.github/workflows/AGENTS.md`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Confirmed pre-fix `.github/workflows/integration.yml` had `workflow_dispatch` and a `push` trigger limited to `main` with path filters for `crates/engine/**`, `crates/core/**`, `tools/k3d-fixtures/**`, and `.github/workflows/integration.yml`.
+- Confirmed the pre-fix workflow had no `pull_request` trigger, so K3D integration tests did not run before merging PRs that changed engine/core/K3D fixture/workflow paths.
+
+Remediation:
+- Added a `pull_request` trigger to `.github/workflows/integration.yml` with the same path filters as the existing `push` trigger.
+- Preserved the existing `workflow_dispatch` and `push` trigger behavior.
+- Kept the existing K3D install, cluster setup, fixture deployment, integration test, and teardown logic intact.
+- Updated `.github/workflows/AGENTS.md` to document that K3D integration tests are PR-gated for engine/core/K3D fixture/workflow changes.
+
+Verification:
+- Pass: `git diff --check`
+- Pass: static confirmation that `.github/workflows/integration.yml` contains a `pull_request` trigger with path filters for `crates/engine/**`, `crates/core/**`, `tools/k3d-fixtures/**`, and `.github/workflows/integration.yml`.
+- Not run locally: K3D integration tests. The K3D gate now runs in GitHub Actions for matching pull requests, `main` pushes, and manual dispatch.
+
+## F-08 — Resource Cache Raw GVK Allowlist
+
+Status: Fixed
+
+Files changed:
+- `apps/desktop/src-tauri/src/main.rs`
+- `REMEDIATION_STATUS.md`
+
+Reproduction / Inspection:
+- Confirmed pre-fix `get_resources` passed caller-supplied `gvk` strings directly to `ResourceStore::list`, and `get_resource` passed caller-supplied `gvk` strings directly to `ResourceStore::get`.
+- Confirmed `search_resources` already iterated `ALL_WATCHED_GVKS`, so it did not issue arbitrary cache lookups.
+- Confirmed known cached frontend resource routes use watched GVK constants, while secrets, namespaces, and CRD/dynamic resource screens use separate direct or dynamic API commands instead of raw cache reads.
+
+Remediation:
+- Added `validate_cached_resource_gvk`, backed by `ALL_WATCHED_GVKS`, for exact allowlist validation before cached `ResourceStore::list`, `ResourceStore::get`, and the related cached `ResourceStore::count` command.
+- Unsupported cached resource types now return the generic sanitized error `Unsupported cached resource type` without echoing arbitrary caller-provided GVK values.
+- Left `list_dynamic_resources` and `get_dynamic_resource` unchanged so CRD/dynamic lookups continue through the live Kubernetes dynamic API path.
+
+Verification:
+- Pass: `cargo fmt --all -- --check`
+- Pass: `git diff --check`
+- Follow-up: `pkg-config --modversion glib-2.0` now resolves `2.80.0` on this host.
+- Host-only status: `cargo check -p telescope-desktop` now advances past `glib-sys` and fails before checking project code because `gdk-sys` cannot find `gdk-3.0.pc` via `pkg-config`.
+- Pass in build container: `./scripts/dev-test.sh run bash -lc 'sudo chown -R pwuser:pwuser /home/pwuser/.cargo /home/pwuser/.rustup /home/pwuser/.local/share/pnpm/store && ./scripts/pnpm.sh -C apps/desktop prepare:frontend && cargo check -p telescope-desktop'`
+- Pass in build container: `./scripts/dev-test.sh run cargo build -p telescope-desktop`
+- Pass: `./scripts/pnpm.sh -C apps/web e2e -- p2-routes.spec.ts` (12 tests)
+
+## Final Global Validation
+
+Status: Passed
+
+Commands:
+- Pass: `./scripts/dev-test.sh` (container-first gate: Rust fmt/clippy/test, pnpm install, web unit tests, web E2E)
+- Pass: `cargo fmt --all -- --check`
+- Pass: `cargo clippy --workspace --exclude telescope-desktop --all-targets --all-features -- -D warnings`
+- Pass: `cargo test --workspace --exclude telescope-desktop --all-features`
+- Pass: `./scripts/pnpm.sh -C apps/web test` (8 files, 67 tests)
+- Pass: `./scripts/pnpm.sh -C apps/web build`
+- Pass: `./scripts/pnpm.sh -C apps/web e2e` (42 tests)
+
+Notes:
+- The first full `cargo test --workspace --exclude telescope-desktop --all-features` run exposed the same hardened trusted-binary fixture issue in `crates/engine/src/kubeconfig.rs`; that test fixture was fixed and the full Rust gate was rerun successfully.
+- `pkg-config --modversion glib-2.0` now resolves `2.80.0`; host-only `cargo check -p telescope-desktop` now advances to `gdk-sys` and remains blocked before checking project code because `gdk-3.0.pc` is not available to `pkg-config`.
+- The desktop Rust app does validate in the repo build container: after `./scripts/pnpm.sh -C apps/desktop prepare:frontend`, both `cargo check -p telescope-desktop` and `cargo build -p telescope-desktop` passed under `./scripts/dev-test.sh run`.

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ telescope-engine = { path = "../../../crates/engine" }
 telescope-core = { path = "../../../crates/core" }
 telescope-azure = { path = "../../../crates/azure" }
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ use telescope_azure::{
 };
 use tokio::sync::{Mutex as TokioMutex, RwLock};
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 
 use telescope_core::{ConnectionState, ResourceEntry, ResourceStore};
@@ -61,6 +62,16 @@ const ALL_WATCHED_GVKS: &[&str] = &[
     "v1/PersistentVolume",
 ];
 
+const UNSUPPORTED_CACHED_RESOURCE_TYPE: &str = "Unsupported cached resource type";
+
+fn validate_cached_resource_gvk(gvk: &str) -> Result<&str, String> {
+    if ALL_WATCHED_GVKS.contains(&gvk) {
+        Ok(gvk)
+    } else {
+        Err(UNSUPPORTED_CACHED_RESOURCE_TYPE.to_string())
+    }
+}
+
 const AI_INSIGHTS_HISTORY_KEY_PREFIX: &str = "ai_insights_history";
 const AI_INSIGHTS_HISTORY_LIMIT: usize = 3;
 const AI_INSIGHTS_SYSTEM_PROMPT: &str = concat!(
@@ -90,7 +101,7 @@ struct AppState {
     active_connection: RwLock<Option<ActiveConnection>>,
     store: Arc<Mutex<ResourceStore>>,
     connection_state: Arc<RwLock<ConnectionState>>,
-    watch_handle: TokioMutex<Option<JoinHandle<()>>>,
+    watch_handle: TokioMutex<Option<WatchTaskHandle>>,
     active_context: RwLock<Option<String>>,
     active_namespace: RwLock<String>,
 }
@@ -99,6 +110,41 @@ struct AppState {
 struct ActiveConnection {
     context_name: String,
     client: kube::Client,
+}
+
+struct WatchTaskHandle {
+    cancellation_token: CancellationToken,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+impl WatchTaskHandle {
+    fn new() -> Self {
+        Self {
+            cancellation_token: CancellationToken::new(),
+            tasks: Vec::new(),
+        }
+    }
+
+    fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+
+    fn push(&mut self, task: JoinHandle<()>) {
+        self.tasks.push(task);
+    }
+
+    fn cancel(&mut self) {
+        self.cancellation_token.cancel();
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for WatchTaskHandle {
+    fn drop(&mut self) {
+        self.cancel();
+    }
 }
 
 async fn write_audit_entry(
@@ -613,12 +659,13 @@ fn get_resources(
     gvk: String,
     namespace: Option<String>,
 ) -> Result<Vec<ResourceEntry>, String> {
+    let gvk = validate_cached_resource_gvk(&gvk)?;
     let store = state
         .store
         .lock()
         .map_err(|e| format!("Store lock failed: {}", e))?;
     store
-        .list(&gvk, namespace.as_deref())
+        .list(gvk, namespace.as_deref())
         .map_err(|e| e.to_string())
 }
 
@@ -709,12 +756,13 @@ fn count_resources(
     gvk: String,
     namespace: Option<String>,
 ) -> Result<u64, String> {
+    let gvk = validate_cached_resource_gvk(&gvk)?;
     let store = state
         .store
         .lock()
         .map_err(|e| format!("Store lock failed: {}", e))?;
     store
-        .count(&gvk, namespace.as_deref())
+        .count(gvk, namespace.as_deref())
         .map_err(|e| e.to_string())
 }
 
@@ -776,13 +824,12 @@ fn get_resource(
     namespace: String,
     name: String,
 ) -> Result<Option<ResourceEntry>, String> {
+    let gvk = validate_cached_resource_gvk(&gvk)?;
     let store = state
         .store
         .lock()
         .map_err(|e| format!("Store lock failed: {}", e))?;
-    store
-        .get(&gvk, &namespace, &name)
-        .map_err(|e| e.to_string())
+    store.get(gvk, &namespace, &name).map_err(|e| e.to_string())
 }
 
 /// List secrets in a namespace via a direct uncached Kubernetes API read.
@@ -837,8 +884,8 @@ async fn get_helm_release_history(
 
 /// Get the user-supplied values for the latest revision of a Helm release.
 ///
-/// By default, sensitive keys (passwords, tokens, secrets, etc.) are redacted.
-/// Pass `reveal: true` to return unredacted values.
+/// Sensitive keys (passwords, tokens, secrets, etc.) are redacted.
+/// Requests to reveal raw values are denied and audited before values are fetched.
 #[tauri::command]
 async fn get_helm_release_values(
     state: State<'_, AppState>,
@@ -846,11 +893,36 @@ async fn get_helm_release_values(
     name: String,
     reveal: Option<bool>,
 ) -> Result<String, String> {
+    let namespace = validate_namespace_param(&namespace)?;
+    let name = validate_k8s_name_param(&name, "name")?;
+
+    if reveal.unwrap_or(false) {
+        let audit_result = write_audit_entry(
+            &state,
+            None,
+            namespace.clone(),
+            "helm_values_reveal",
+            "HelmRelease",
+            name.clone(),
+            "denied",
+            Some("requested_reveal=true".to_string()),
+        )
+        .await;
+
+        return match audit_result {
+            Ok(()) => Err("Revealing raw Helm values is disabled for security.".to_string()),
+            Err(_) => Err(
+                "Revealing raw Helm values is disabled for security, and the denied attempt could not be audited."
+                    .to_string(),
+            ),
+        };
+    }
+
     let client = active_client(&state).await?;
     let mut values = telescope_engine::helm::get_release_values(&client, &namespace, &name)
         .await
         .map_err(|e| e.to_string())?;
-    if !reveal.unwrap_or(false) && !values.trim_start().starts_with('#') {
+    if !values.trim_start().starts_with('#') {
         let mut json = serde_yaml::from_str::<serde_json::Value>(&values)
             .map_err(|e| format!("Failed to parse Helm values YAML: {e}"))?;
         telescope_engine::helm::redact_sensitive_values(&mut json);
@@ -1652,9 +1724,9 @@ fn validate_create_node_pool_config(
 /// Abort the current watch task if one is running.
 async fn abort_watch(state: &State<'_, AppState>) {
     let mut handle = state.watch_handle.lock().await;
-    if let Some(h) = handle.take() {
-        h.abort();
-        info!("Previous watch task aborted");
+    if let Some(mut watch_tasks) = handle.take() {
+        watch_tasks.cancel();
+        info!("Previous watch tasks cancelled");
     }
 }
 
@@ -1846,88 +1918,87 @@ async fn spawn_watch_task(
     let watcher = telescope_engine::ResourceWatcher::new(client, Arc::clone(&store));
     watcher.register_watches(29); // 28 aux watchers + 1 pod watcher
     let mut state_rx = watcher.state_receiver();
+    let mut watch_tasks = WatchTaskHandle::new();
 
     // Spawn a task to forward state changes from the watcher to the UI.
     let conn_state_fwd = Arc::clone(&conn_state);
     let app_fwd = app_handle.clone();
+    let cancellation_token = watch_tasks.cancellation_token();
     let state_forwarder = tokio::spawn(async move {
-        while state_rx.changed().await.is_ok() {
-            let new_state = state_rx.borrow().clone();
-            {
-                let mut s = conn_state_fwd.write().await;
-                *s = new_state.clone();
+        loop {
+            tokio::select! {
+                changed = state_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    let new_state = state_rx.borrow().clone();
+                    {
+                        let mut s = conn_state_fwd.write().await;
+                        *s = new_state.clone();
+                    }
+                    app_fwd.emit("connection-state-changed", &new_state).ok();
+                }
+                _ = cancellation_token.cancelled() => {
+                    break;
+                }
             }
-            app_fwd.emit("connection-state-changed", &new_state).ok();
         }
     });
+    watch_tasks.push(state_forwarder);
 
-    // Collect auxiliary task handles so the main task can abort them on exit.
-    let mut aux_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+    macro_rules! spawn_watch {
+        ($watcher:expr, $tasks:ident, $method:ident, $label:expr) => {{
+            let w = $watcher.clone();
+            let cancellation_token = $tasks.cancellation_token();
+            $tasks.push(tokio::spawn(async move {
+                tokio::select! {
+                    result = w.$method() => {
+                        if let Err(e) = result {
+                            error!("{} watch error: {}", $label, e);
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {}
+                }
+            }));
+        }};
+    }
 
     // -- Cluster-wide / cluster-scoped watchers --
 
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_all_events().await {
-            error!("Events watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_nodes().await {
-            error!("Node watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_cluster_roles().await {
-            error!("ClusterRole watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_cluster_role_bindings().await {
-            error!("ClusterRoleBinding watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_priority_classes().await {
-            error!("PriorityClass watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_validating_webhooks().await {
-            error!("ValidatingWebhookConfiguration watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_mutating_webhooks().await {
-            error!("MutatingWebhookConfiguration watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_storage_classes().await {
-            error!("StorageClass watch error: {}", e);
-        }
-    }));
-
-    let w = watcher.clone();
-    aux_tasks.push(tokio::spawn(async move {
-        if let Err(e) = w.watch_persistent_volumes().await {
-            error!("PersistentVolume watch error: {}", e);
-        }
-    }));
+    spawn_watch!(watcher, watch_tasks, watch_all_events, "Events");
+    spawn_watch!(watcher, watch_tasks, watch_nodes, "Node");
+    spawn_watch!(watcher, watch_tasks, watch_cluster_roles, "ClusterRole");
+    spawn_watch!(
+        watcher,
+        watch_tasks,
+        watch_cluster_role_bindings,
+        "ClusterRoleBinding"
+    );
+    spawn_watch!(
+        watcher,
+        watch_tasks,
+        watch_priority_classes,
+        "PriorityClass"
+    );
+    spawn_watch!(
+        watcher,
+        watch_tasks,
+        watch_validating_webhooks,
+        "ValidatingWebhookConfiguration"
+    );
+    spawn_watch!(
+        watcher,
+        watch_tasks,
+        watch_mutating_webhooks,
+        "MutatingWebhookConfiguration"
+    );
+    spawn_watch!(watcher, watch_tasks, watch_storage_classes, "StorageClass");
+    spawn_watch!(
+        watcher,
+        watch_tasks,
+        watch_persistent_volumes,
+        "PersistentVolume"
+    );
 
     // -- Namespaced resource watchers --
     // Uses a macro to reduce boilerplate for each resource type.
@@ -1935,72 +2006,84 @@ async fn spawn_watch_task(
         ($watcher:expr, $ns:expr, $tasks:ident, $method:ident, $label:expr) => {{
             let w = $watcher.clone();
             let ns_clone = $ns.clone();
+            let cancellation_token = $tasks.cancellation_token();
             $tasks.push(tokio::spawn(async move {
-                if let Err(e) = w.$method(&ns_clone).await {
-                    error!("{} watch error: {}", $label, e);
+                tokio::select! {
+                    result = w.$method(&ns_clone) => {
+                        if let Err(e) = result {
+                            error!("{} watch error: {}", $label, e);
+                        }
+                    }
+                    _ = cancellation_token.cancelled() => {}
                 }
             }));
         }};
     }
 
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_deployments, "Deployment");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_statefulsets, "StatefulSet");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_daemonsets, "DaemonSet");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_replicasets, "ReplicaSet");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_services, "Service");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_config_maps, "ConfigMap");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_jobs, "Job");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_cronjobs, "CronJob");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_ingresses, "Ingress");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_deployments, "Deployment");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_statefulsets, "StatefulSet");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_daemonsets, "DaemonSet");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_replicasets, "ReplicaSet");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_services, "Service");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_config_maps, "ConfigMap");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_jobs, "Job");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_cronjobs, "CronJob");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_ingresses, "Ingress");
     spawn_ns_watch!(
         watcher,
         ns,
-        aux_tasks,
+        watch_tasks,
         watch_network_policies,
         "NetworkPolicy"
     );
     spawn_ns_watch!(
         watcher,
         ns,
-        aux_tasks,
+        watch_tasks,
         watch_endpoint_slices,
         "EndpointSlice"
     );
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_pvcs, "PVC");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_pvcs, "PVC");
     spawn_ns_watch!(
         watcher,
         ns,
-        aux_tasks,
+        watch_tasks,
         watch_resource_quotas,
         "ResourceQuota"
     );
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_limit_ranges, "LimitRange");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_roles, "Role");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_role_bindings, "RoleBinding");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_limit_ranges, "LimitRange");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_roles, "Role");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_role_bindings, "RoleBinding");
     spawn_ns_watch!(
         watcher,
         ns,
-        aux_tasks,
+        watch_tasks,
         watch_service_accounts,
         "ServiceAccount"
     );
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_hpas, "HPA");
-    spawn_ns_watch!(watcher, ns, aux_tasks, watch_pod_disruption_budgets, "PDB");
+    spawn_ns_watch!(watcher, ns, watch_tasks, watch_hpas, "HPA");
+    spawn_ns_watch!(
+        watcher,
+        ns,
+        watch_tasks,
+        watch_pod_disruption_budgets,
+        "PDB"
+    );
 
-    // Spawn the main watch task (pods + lifecycle coordinator).
-    let task = tokio::spawn(async move {
-        if let Err(e) = watcher.watch_pods(&ns).await {
-            error!("Pod watch error: {}", e);
+    let cancellation_token = watch_tasks.cancellation_token();
+    watch_tasks.push(tokio::spawn(async move {
+        tokio::select! {
+            result = watcher.watch_pods(&ns) => {
+                if let Err(e) = result {
+                    error!("Pod watch error: {}", e);
+                }
+            }
+            _ = cancellation_token.cancelled() => {}
         }
-        // When the pod watch ends, abort the state forwarder and all auxiliary watchers.
-        state_forwarder.abort();
-        for t in aux_tasks {
-            t.abort();
-        }
-    });
+    }));
 
     let mut handle = state.watch_handle.lock().await;
-    *handle = Some(task);
+    *handle = Some(watch_tasks);
 }
 
 /// Restart a Deployment, StatefulSet, or DaemonSet rollout.

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -27,6 +27,7 @@ import {
   clearAiInsightsHistory,
   generateAiInsights,
   getAiInsightsSettings,
+  getHelmReleaseValues,
   listAksNodePools,
   listAiInsightsHistory,
   onApiError,
@@ -73,6 +74,68 @@ describe('listAksNodePools', () => {
 
     await expect(listAksNodePools()).rejects.toThrow('ARM lookup failed');
     expect(invokeMock).toHaveBeenCalledWith('list_aks_node_pools', undefined);
+  });
+
+  it('redacts raw paths and secrets from thrown errors, listeners, and console logs', async () => {
+    const listener = vi.fn();
+    const unsubscribe = onApiError(listener);
+    const rawMessage =
+      'Failed at /home/alice/.kube/config and C:\\Users\\Alice\\helm.exe token=super-secret Bearer abc.def';
+
+    invokeMock.mockRejectedValue(new Error(rawMessage));
+
+    let message = '';
+    try {
+      await listAksNodePools();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('[redacted path]');
+    expect(message).toContain('token=[redacted]');
+    expect(message).toContain('Bearer [redacted]');
+    expect(message).not.toContain('/home/alice');
+    expect(message).not.toContain('C:\\Users\\Alice');
+    expect(message).not.toContain('super-secret');
+    expect(message).not.toContain('abc.def');
+    expect(listener).toHaveBeenCalledWith({
+      command: 'list_aks_node_pools',
+      message,
+    });
+
+    const consoleText = JSON.stringify(vi.mocked(console.error).mock.calls);
+    expect(consoleText).not.toContain('/home/alice');
+    expect(consoleText).not.toContain('C:\\Users\\Alice');
+    expect(consoleText).not.toContain('super-secret');
+    expect(consoleText).not.toContain('abc.def');
+
+    unsubscribe();
+  });
+});
+
+describe('getHelmReleaseValues', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    vi.stubGlobal('window', {
+      __TAURI_INTERNALS__: {
+        invoke: invokeMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests redacted Helm values without a reveal flag', async () => {
+    invokeMock.mockResolvedValue('controller:\n  admissionWebhooks:\n    secretName: "********"\n');
+
+    await expect(getHelmReleaseValues('default', 'ingress-nginx')).resolves.toContain('controller:');
+
+    expect(invokeMock).toHaveBeenCalledWith('get_helm_release_values', {
+      namespace: 'default',
+      name: 'ingress-nginx',
+    });
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -39,7 +39,7 @@ async function invoke<T>(command: string, args?: Record<string, unknown>): Promi
     return result;
   } catch (e) {
     const error = toError(e);
-    console.error(`[telescope] invoke ${command} FAILED:`, error);
+    console.error(`[telescope] invoke ${command} failed`);
     throw error;
   }
 }
@@ -48,14 +48,34 @@ async function invoke<T>(command: string, args?: Record<string, unknown>): Promi
 
 type ApiErrorListener = (error: { command: string; message: string }) => void;
 const errorListeners: ApiErrorListener[] = [];
+const REDACTED_SECRET = '[redacted]';
+const REDACTED_PATH = '[redacted path]';
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(api[_-]?key|token|secret|password|passwd|client[_-]?secret|access[_-]?key)\b\s*[:=]\s*["']?[^\s,;'"`)}]+/gi;
+const BEARER_TOKEN_PATTERN = /\bbearer\s+[a-z0-9._~+/=-]+/gi;
+const WINDOWS_PATH_PATTERN = /\b[A-Z]:\\[^\s,;'"`)}\]]+/gi;
+const UNIX_PATH_PATTERN =
+  /(^|[\s'"`(=:{,])\/(?:home|Users|var|tmp|private|etc|opt|usr|snap|mnt|Volumes)\/[^\s,;'"`)}\]]+/g;
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String(error.message);
+  }
+  return String(error);
+}
+
+function sanitizeApiErrorMessage(message: string): string {
+  return message
+    .replace(SECRET_ASSIGNMENT_PATTERN, `$1=${REDACTED_SECRET}`)
+    .replace(BEARER_TOKEN_PATTERN, `Bearer ${REDACTED_SECRET}`)
+    .replace(WINDOWS_PATH_PATTERN, REDACTED_PATH)
+    .replace(UNIX_PATH_PATTERN, `$1${REDACTED_PATH}`);
+}
 
 function toError(error: unknown): Error {
-  if (error instanceof Error) return error;
-  if (typeof error === 'string') return new Error(error);
-  if (error && typeof error === 'object' && 'message' in error) {
-    return new Error(String(error.message));
-  }
-  return new Error(String(error));
+  return new Error(sanitizeApiErrorMessage(extractErrorMessage(error)));
 }
 
 /** Subscribe to API errors that are caught and suppressed by helpers. Returns an unsubscribe function. */
@@ -69,7 +89,7 @@ export function onApiError(listener: ApiErrorListener): () => void {
 
 function notifyApiError(command: string, error: unknown) {
   const message = toError(error).message;
-  console.error(`[telescope] ${command} failed:`, message);
+  console.error(`[telescope] ${command} failed`);
   for (const listener of errorListeners) {
     listener({ command, message });
   }
@@ -482,10 +502,9 @@ export async function getHelmReleaseHistory(namespace: string, name: string): Pr
   }
 }
 
-/** Get user-supplied values for the latest revision of a Helm release.
- *  Sensitive keys are redacted by default; pass `reveal: true` to see raw values. */
-export async function getHelmReleaseValues(namespace: string, name: string, reveal = false): Promise<string> {
-  return invoke<string>('get_helm_release_values', { namespace, name, reveal });
+/** Get redacted user-supplied values for the latest revision of a Helm release. */
+export async function getHelmReleaseValues(namespace: string, name: string): Promise<string> {
+  return invoke<string>('get_helm_release_values', { namespace, name });
 }
 
 /** Roll back a Helm release to a specific revision using the helm CLI. */

--- a/apps/web/src/routes/helm/[namespace]/[name]/+page.svelte
+++ b/apps/web/src/routes/helm/[namespace]/[name]/+page.svelte
@@ -22,8 +22,6 @@
   let valuesLoading = $state(false);
   let valuesError: string | null = $state(null);
   let copied = $state(false);
-  let valuesRevealed = $state(false);
-  let showRevealDialog = $state(false);
 
   // Rollback state
   let rollbackTarget: HelmRelease | null = $state(null);
@@ -83,32 +81,18 @@
     }
   }
 
-  async function loadValues(reveal = false) {
+  async function loadValues() {
     valuesLoading = true;
     valuesError = null;
     try {
-      const yaml = await getHelmReleaseValues(namespace, releaseName, reveal);
+      const yaml = await getHelmReleaseValues(namespace, releaseName);
       valuesYaml = yaml;
       editedValues = yaml;
-      valuesRevealed = reveal;
     } catch (e) {
       valuesError = e instanceof Error ? e.message : 'Failed to load values';
     } finally {
       valuesLoading = false;
     }
-  }
-
-  function requestReveal() {
-    showRevealDialog = true;
-  }
-
-  function confirmReveal() {
-    showRevealDialog = false;
-    loadValues(true);
-  }
-
-  function hideValues() {
-    loadValues(false);
   }
 
   function generateUpgradeCommand(): string {
@@ -215,24 +199,6 @@
         {:else if valuesError}
           <p role="alert" class="error">{valuesError}</p>
         {:else}
-          <div class="values-toolbar">
-            {#if valuesRevealed}
-              <div class="reveal-warning">
-                <span>
-                  <Icon name="prod-warning" size={16} aria-hidden="true" />
-                  Sensitive values are now visible
-                </span>
-                <button class="hide-btn" onclick={hideValues} data-testid="hide-sensitive-values">
-                  <Icon name="hide-values" size={14} aria-hidden="true" /> Hide Sensitive Values
-                </button>
-              </div>
-            {:else}
-              <button class="reveal-btn" onclick={requestReveal} data-testid="reveal-sensitive-values">
-                <Icon name="show-values" size={14} aria-hidden="true" /> Reveal Sensitive Values
-              </button>
-            {/if}
-          </div>
-
           <YamlEditor content={valuesYaml} onchange={(v) => { editedValues = v; }} />
 
           <div class="upgrade-section">
@@ -330,15 +296,6 @@
   productionContext={namespace === 'production' || namespace === 'prod'}
   onconfirm={confirmRollback}
   oncancel={() => { showRollbackDialog = false; }}
-/>
-
-<ConfirmDialog
-  open={showRevealDialog}
-  title="Reveal Sensitive Values"
-  message="This will display unredacted passwords, tokens, and other secrets. Make sure no one can see your screen."
-  confirmText="Reveal"
-  onconfirm={confirmReveal}
-  oncancel={() => { showRevealDialog = false; }}
 />
 
 <style>
@@ -517,43 +474,4 @@
     color: #ef5350;
   }
 
-  .values-toolbar {
-    display: flex;
-    align-items: center;
-    margin-bottom: 0.75rem;
-  }
-  .reveal-btn {
-    background: #21262d;
-    color: #c9d1d9;
-    border: 1px solid #30363d;
-    padding: 0.4rem 0.75rem;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    white-space: nowrap;
-  }
-  .reveal-btn:hover { background: #30363d; }
-  .hide-btn {
-    background: transparent;
-    color: #58a6ff;
-    border: 1px solid #58a6ff;
-    padding: 0.3rem 0.6rem;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    white-space: nowrap;
-    margin-left: 0.75rem;
-  }
-  .hide-btn:hover { background: rgba(88, 166, 255, 0.1); }
-  .reveal-warning {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: rgba(255, 193, 7, 0.1);
-    border: 1px solid rgba(255, 193, 7, 0.3);
-    color: #ffc107;
-    padding: 0.4rem 0.75rem;
-    border-radius: 4px;
-    font-size: 0.85rem;
-  }
 </style>

--- a/apps/web/tests-e2e/detail-reload.spec.ts
+++ b/apps/web/tests-e2e/detail-reload.spec.ts
@@ -26,3 +26,37 @@ test('helm detail renders correctly from route params', async ({ page }) => {
   await expect(page.locator('.app-shell')).toBeVisible({ timeout: 15000 });
   await expect(page.getByRole('heading', { name: 'ingress-nginx' })).toBeVisible();
 });
+
+test('helm detail does not expose Helm values reveal UI and rejects reveal IPC in tests', async ({ page }) => {
+  await page.goto('/helm/default/ingress-nginx');
+  await expect(page.locator('.app-shell')).toBeVisible({ timeout: 15000 });
+  await expect(page.getByRole('heading', { name: 'ingress-nginx' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Values' }).click();
+  await expect(page.getByTestId('reveal-sensitive-values')).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /reveal sensitive values/i })).toHaveCount(0);
+
+  await expect(page.evaluate(() => {
+    const tauri = (window as Window & { __TEST_TAURI__: { calls: Array<{ cmd: string; args: Record<string, unknown> }> } }).__TEST_TAURI__;
+    return tauri.calls.some((entry) => entry.cmd === 'get_helm_release_values' && entry.args.reveal === true);
+  })).resolves.toBe(false);
+
+  await expect(page.evaluate(async () => {
+    const tauri = (window as Window & {
+      __TAURI_INTERNALS__: {
+        invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+      };
+    }).__TAURI_INTERNALS__;
+
+    try {
+      await tauri.invoke('get_helm_release_values', {
+        namespace: 'default',
+        name: 'ingress-nginx',
+        reveal: true,
+      });
+      return 'resolved';
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+  })).resolves.toContain('Revealing raw Helm values is disabled for security.');
+});

--- a/apps/web/tests-e2e/helpers/mock-tauri.ts
+++ b/apps/web/tests-e2e/helpers/mock-tauri.ts
@@ -505,7 +505,10 @@ export async function installMockTauri(page: Page, scenario: MockTauriScenario =
               return clone(state.helmReleases.filter(r => r.name === releaseName && r.namespace === ns));
             }
             case 'get_helm_release_values':
-              return '';
+              if (args.reveal === true) {
+                throw new Error('Revealing raw Helm values is disabled for security.');
+              }
+              return 'controller:\n  replicaCount: 1\n  admissionWebhooks:\n    secretName: "********"\n';
             case 'helm_uninstall': {
               const releaseName = String(args.name);
               const ns = String(args.namespace);

--- a/crates/azure/src/resolve.rs
+++ b/crates/azure/src/resolve.rs
@@ -388,8 +388,53 @@ fn extract_subscription_from_arm_id(arm_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
     use telescope_core::store::ResourceStore;
+
+    static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TrustedBinaryFixture {
+        path: PathBuf,
+    }
+
+    impl TrustedBinaryFixture {
+        fn new() -> Self {
+            let unique_id = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "telescope-az-binary-test-{}-{timestamp}-{unique_id}",
+                std::process::id()
+            ));
+
+            fs::write(&path, b"trusted az test helper").expect("write trusted az fixture");
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                    .expect("set trusted az fixture permissions");
+            }
+
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TrustedBinaryFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
 
     #[test]
     fn extract_fqdn_from_aks_url() {
@@ -424,16 +469,20 @@ mod tests {
 
     #[test]
     fn resolve_az_binary_path_accepts_trusted_binary_name() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedBinaryFixture::new();
         let name = executable
+            .path()
             .file_name()
             .and_then(|value| value.to_str())
             .expect("binary name");
 
-        let resolved = resolve_az_binary_path_with(name, vec![executable.clone()])
+        let resolved = resolve_az_binary_path_with(name, vec![executable.path().to_path_buf()])
             .expect("trusted az path should resolve");
 
-        assert_eq!(resolved, executable.canonicalize().expect("canonical path"));
+        assert_eq!(
+            resolved,
+            executable.path().canonicalize().expect("canonical path")
+        );
     }
 
     #[test]

--- a/crates/core/src/trusted_binary.rs
+++ b/crates/core/src/trusted_binary.rs
@@ -101,34 +101,86 @@ fn validate_binary_permissions(_path: &Path, _metadata: &Metadata) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::resolve_trusted_binary;
 
+    static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TrustedBinaryFixture {
+        path: PathBuf,
+    }
+
+    impl TrustedBinaryFixture {
+        fn new() -> Self {
+            let unique_id = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "telescope-trusted-binary-test-{}-{timestamp}-{unique_id}",
+                std::process::id()
+            ));
+
+            fs::write(&path, b"trusted test helper").expect("write trusted binary fixture");
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                    .expect("set trusted binary fixture permissions");
+            }
+
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TrustedBinaryFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
     #[test]
     fn resolve_trusted_binary_accepts_trusted_absolute_path() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedBinaryFixture::new();
         let resolved = resolve_trusted_binary(
-            executable.to_str().expect("utf-8 path"),
-            vec![executable.clone()],
+            executable.path().to_str().expect("utf-8 path"),
+            vec![executable.path().to_path_buf()],
         )
         .expect("trusted absolute path should resolve");
 
-        assert_eq!(resolved, executable.canonicalize().expect("canonical path"));
+        assert_eq!(
+            resolved,
+            executable.path().canonicalize().expect("canonical path")
+        );
     }
 
     #[test]
     fn resolve_trusted_binary_accepts_trusted_binary_name() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedBinaryFixture::new();
         let name = executable
+            .path()
             .file_name()
             .and_then(|name| name.to_str())
             .expect("binary name");
 
-        let resolved = resolve_trusted_binary(name, vec![executable.clone()])
+        let resolved = resolve_trusted_binary(name, vec![executable.path().to_path_buf()])
             .expect("trusted binary name should resolve");
 
-        assert_eq!(resolved, executable.canonicalize().expect("canonical path"));
+        assert_eq!(
+            resolved,
+            executable.path().canonicalize().expect("canonical path")
+        );
     }
 
     #[test]
@@ -141,9 +193,9 @@ mod tests {
 
     #[test]
     fn resolve_trusted_binary_rejects_untrusted_absolute_paths() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedBinaryFixture::new();
         let err = resolve_trusted_binary(
-            executable.to_str().expect("utf-8 path"),
+            executable.path().to_str().expect("utf-8 path"),
             Vec::<PathBuf>::new(),
         )
         .expect_err("untrusted absolute path should be blocked");

--- a/crates/engine/src/helm.rs
+++ b/crates/engine/src/helm.rs
@@ -311,31 +311,43 @@ fn validate_k8s_name(name: &str) -> crate::Result<()> {
     Ok(())
 }
 
-fn map_helm_uninstall_error(stderr: &str, stdout: &str) -> String {
+fn resolve_helm_binary_for_command(action: &str) -> crate::Result<PathBuf> {
+    resolve_helm_binary_path().map_err(|_| helm_command_unavailable_error(action))
+}
+
+fn helm_command_unavailable_error(action: &str) -> crate::EngineError {
+    crate::EngineError::Other(format!(
+        "Helm {action} failed: command unavailable. Install Helm in a trusted system location."
+    ))
+}
+
+fn map_helm_command_error(action: &str, stderr: &str, stdout: &str) -> String {
     let detail = if !stderr.trim().is_empty() {
-        stderr.trim().to_string()
-    } else if !stdout.trim().is_empty() {
-        stdout.trim().to_string()
+        stderr.trim()
     } else {
-        "Helm uninstall command failed with no output".to_string()
+        stdout.trim()
     };
     let detail_lower = detail.to_lowercase();
 
     if detail_lower.contains("release: not found") || detail_lower.contains("not found") {
-        format!("Helm uninstall failed: release not found. {detail}")
+        format!("Helm {action} failed: release not found")
     } else if detail_lower.contains("forbidden")
         || detail_lower.contains("unauthorized")
         || detail_lower.contains("permission denied")
     {
-        format!("Helm uninstall failed: permission denied. {detail}")
+        format!("Helm {action} failed: permission denied")
     } else if detail_lower.contains("timed out waiting")
         || detail_lower.contains("deadline exceeded")
         || detail_lower.contains("timeout")
     {
-        format!("Helm uninstall failed: operation timed out. {detail}")
+        format!("Helm {action} failed: operation timed out")
     } else {
-        format!("Helm uninstall failed: {detail}")
+        format!("Helm {action} failed: command failed")
     }
+}
+
+fn map_helm_uninstall_error(stderr: &str, stdout: &str) -> String {
+    map_helm_command_error("uninstall", stderr, stdout)
 }
 
 /// Keys whose values should be redacted in Helm values display.
@@ -421,7 +433,7 @@ pub async fn rollback_release(namespace: &str, name: &str, revision: i32) -> cra
         ));
     }
 
-    let helm_binary = resolve_helm_binary_path()?;
+    let helm_binary = resolve_helm_binary_for_command("rollback")?;
     let revision_arg = revision.to_string();
     let output = tokio::process::Command::new(&helm_binary)
         .args([
@@ -434,29 +446,17 @@ pub async fn rollback_release(namespace: &str, name: &str, revision: i32) -> cra
         .kill_on_drop(true)
         .output()
         .await
-        .map_err(|e| {
-            crate::EngineError::Other(format!(
-                "Failed to execute Helm CLI at {}: {e}",
-                helm_binary.display()
-            ))
-        })?;
+        .map_err(|_| helm_command_unavailable_error("rollback"))?;
 
     if output.status.success() {
         Ok(format!("Rolled back {name} to revision {revision}"))
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!("helm exited with status {}", output.status)
-        };
-        Err(crate::EngineError::Other(format!(
-            "Rollback via {} failed: {detail}",
-            helm_binary.display()
-        )))
+        let detail = map_helm_command_error(
+            "rollback",
+            String::from_utf8_lossy(&output.stderr).as_ref(),
+            String::from_utf8_lossy(&output.stdout).as_ref(),
+        );
+        Err(crate::EngineError::Other(detail))
     }
 }
 
@@ -465,18 +465,13 @@ pub async fn helm_uninstall(namespace: &str, name: &str) -> crate::Result<String
     validate_k8s_name(namespace)?;
     validate_k8s_name(name)?;
 
-    let helm_binary = resolve_helm_binary_path()?;
+    let helm_binary = resolve_helm_binary_for_command("uninstall")?;
     let output = tokio::process::Command::new(&helm_binary)
         .args(["uninstall", name, "-n", namespace])
         .kill_on_drop(true)
         .output()
         .await
-        .map_err(|error| {
-            crate::EngineError::Other(format!(
-                "Failed to execute Helm CLI at {}: {error}",
-                helm_binary.display()
-            ))
-        })?;
+        .map_err(|_| helm_command_unavailable_error("uninstall"))?;
 
     if output.status.success() {
         Ok(format!(
@@ -487,10 +482,7 @@ pub async fn helm_uninstall(namespace: &str, name: &str) -> crate::Result<String
             String::from_utf8_lossy(&output.stderr).as_ref(),
             String::from_utf8_lossy(&output.stdout).as_ref(),
         );
-        Err(crate::EngineError::Other(format!(
-            "{detail} (via {})",
-            helm_binary.display()
-        )))
+        Err(crate::EngineError::Other(detail))
     }
 }
 
@@ -944,6 +936,19 @@ mod tests {
         assert!(msg.contains("operation timed out"));
     }
 
+    #[test]
+    fn map_helm_uninstall_error_omits_raw_command_detail() {
+        let msg = map_helm_uninstall_error(
+            "Error: open /home/alice/.kube/config: permission denied token=super-secret",
+            "",
+        );
+
+        assert_eq!(msg, "Helm uninstall failed: permission denied");
+        assert!(!msg.contains("/home/alice"));
+        assert!(!msg.contains("token="));
+        assert!(!msg.contains("super-secret"));
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn helm_uninstall_with_valid_release_name_succeeds() {
@@ -976,7 +981,53 @@ mod tests {
         let msg = err.to_string();
 
         assert!(msg.contains("release not found"));
-        assert!(msg.contains("via"));
+        assert!(!msg.contains(&helm_binary.path.display().to_string()));
+        assert!(!msg.contains("Release not loaded"));
+        assert!(!msg.contains("via"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn helm_uninstall_sanitizes_raw_stderr_and_binary_path() {
+        let _env_lock = helm_env_lock().lock().unwrap();
+        let helm_binary = create_mock_helm_binary(
+            "uninstall-sensitive-error",
+            "Error: open /home/alice/.kube/config: permission denied token=super-secret",
+            1,
+        );
+        let _env = ScopedEnvVar::set(HELM_BINARY_PATH_ENV, &helm_binary.path);
+
+        let err = helm_uninstall("default", "demo-release").await.unwrap_err();
+        let msg = err.to_string();
+
+        assert_eq!(msg, "Helm uninstall failed: permission denied");
+        assert!(!msg.contains(&helm_binary.path.display().to_string()));
+        assert!(!msg.contains("/home/alice"));
+        assert!(!msg.contains("token="));
+        assert!(!msg.contains("super-secret"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn rollback_release_sanitizes_raw_stderr_and_binary_path() {
+        let _env_lock = helm_env_lock().lock().unwrap();
+        let helm_binary = create_mock_helm_binary(
+            "rollback-sensitive-error",
+            "Error: open /home/alice/.kube/config: permission denied token=super-secret",
+            1,
+        );
+        let _env = ScopedEnvVar::set(HELM_BINARY_PATH_ENV, &helm_binary.path);
+
+        let err = rollback_release("default", "demo-release", 1)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+
+        assert_eq!(msg, "Helm rollback failed: permission denied");
+        assert!(!msg.contains(&helm_binary.path.display().to_string()));
+        assert!(!msg.contains("/home/alice"));
+        assert!(!msg.contains("token="));
+        assert!(!msg.contains("super-secret"));
     }
 
     #[tokio::test]

--- a/crates/engine/src/kubeconfig.rs
+++ b/crates/engine/src/kubeconfig.rs
@@ -213,11 +213,56 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{pin_exec_helper_paths_with, resolve_exec_helper_command_with};
     use kube::config::Kubeconfig;
     use serde_json::json;
+
+    static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TrustedExecFixture {
+        path: PathBuf,
+    }
+
+    impl TrustedExecFixture {
+        fn new() -> Self {
+            let unique_id = FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "telescope-exec-helper-test-{}-{timestamp}-{unique_id}",
+                std::process::id()
+            ));
+
+            fs::write(&path, b"trusted exec test helper").expect("write trusted exec fixture");
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                    .expect("set trusted exec fixture permissions");
+            }
+
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TrustedExecFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
 
     fn kubeconfig_with_exec(command: &str) -> Kubeconfig {
         serde_json::from_value(json!({
@@ -258,16 +303,21 @@ mod tests {
 
     #[test]
     fn resolve_exec_helper_command_accepts_trusted_binary_name() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedExecFixture::new();
         let name = executable
+            .path()
             .file_name()
             .and_then(|value| value.to_str())
             .expect("binary name");
 
-        let resolved = resolve_exec_helper_command_with(name, vec![executable.clone()])
-            .expect("trusted helper should resolve");
+        let resolved =
+            resolve_exec_helper_command_with(name, vec![executable.path().to_path_buf()])
+                .expect("trusted helper should resolve");
 
-        assert_eq!(resolved, executable.canonicalize().expect("canonical path"));
+        assert_eq!(
+            resolved,
+            executable.path().canonicalize().expect("canonical path")
+        );
     }
 
     #[test]
@@ -280,16 +330,21 @@ mod tests {
 
     #[test]
     fn pin_exec_helper_paths_rewrites_trusted_exec_commands() {
-        let executable = std::env::current_exe().expect("current test executable");
+        let executable = TrustedExecFixture::new();
         let name = executable
+            .path()
             .file_name()
             .and_then(|value| value.to_str())
             .expect("binary name")
             .to_string();
         let mut kubeconfig = kubeconfig_with_exec(&name);
 
-        pin_exec_helper_paths_with(&mut kubeconfig, Some("demo"), vec![executable.clone()])
-            .expect("trusted exec helper should be accepted");
+        pin_exec_helper_paths_with(
+            &mut kubeconfig,
+            Some("demo"),
+            vec![executable.path().to_path_buf()],
+        )
+        .expect("trusted exec helper should be accepted");
 
         let rewritten = kubeconfig.auth_infos[0]
             .auth_info
@@ -300,6 +355,7 @@ mod tests {
         assert_eq!(
             rewritten,
             executable
+                .path()
                 .canonicalize()
                 .expect("canonical path")
                 .to_string_lossy()

--- a/crates/engine/src/portforward.rs
+++ b/crates/engine/src/portforward.rs
@@ -12,6 +12,31 @@ use tokio::net::TcpListener;
 static ACTIVE_FORWARDS: AtomicUsize = AtomicUsize::new(0);
 const MAX_FORWARDS: usize = 10;
 
+#[derive(Debug)]
+struct ActiveForwardGuard;
+
+impl ActiveForwardGuard {
+    fn acquire() -> crate::Result<Self> {
+        ACTIVE_FORWARDS
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                (current < MAX_FORWARDS).then_some(current + 1)
+            })
+            .map(|_| Self)
+            .map_err(|_| {
+                crate::EngineError::Other(format!(
+                    "Port forward limit reached: maximum {MAX_FORWARDS} concurrent forwards allowed"
+                ))
+            })
+    }
+}
+
+impl Drop for ActiveForwardGuard {
+    fn drop(&mut self) {
+        let previous = ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(previous > 0, "active forward counter underflow");
+    }
+}
+
 /// Idle timeout for the accept loop (1 hour).
 const IDLE_TIMEOUT: Duration = Duration::from_secs(3600);
 
@@ -52,19 +77,12 @@ pub async fn start_port_forward(client: &Client, req: &PortForwardRequest) -> cr
         ));
     }
 
-    // Enforce concurrent-forward limit
-    let prev = ACTIVE_FORWARDS.fetch_add(1, Ordering::SeqCst);
-    if prev >= MAX_FORWARDS {
-        ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
-        return Err(crate::EngineError::Other(format!(
-            "Port forward limit reached: maximum {MAX_FORWARDS} concurrent forwards allowed"
-        )));
-    }
+    // Enforce concurrent-forward limit. The guard releases the slot on every return path.
+    let active_forward_guard = ActiveForwardGuard::acquire()?;
 
     // Verify the pod exists before binding the local port
     let pods: Api<Pod> = Api::namespaced(client.clone(), &req.namespace);
     if let Err(e) = pods.get(&req.pod).await {
-        ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
         return Err(e.into());
     }
 
@@ -72,16 +90,12 @@ pub async fn start_port_forward(client: &Client, req: &PortForwardRequest) -> cr
     let listener = TcpListener::bind(format!("127.0.0.1:{}", req.local_port))
         .await
         .map_err(|e| {
-            ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
             crate::EngineError::Other(format!("Failed to bind port {}: {}", req.local_port, e))
         })?;
 
     let actual_port = listener
         .local_addr()
-        .map_err(|e| {
-            ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
-            crate::EngineError::Other(e.to_string())
-        })?
+        .map_err(|e| crate::EngineError::Other(e.to_string()))?
         .port();
 
     let pod_name = req.pod.clone();
@@ -90,6 +104,8 @@ pub async fn start_port_forward(client: &Client, req: &PortForwardRequest) -> cr
     // Spawn the forwarding loop — accepts connections and pipes them to the pod.
     // The loop is wrapped in an idle timeout so abandoned forwards are cleaned up.
     tokio::spawn(async move {
+        let _active_forward_guard = active_forward_guard;
+
         let result = tokio::time::timeout(IDLE_TIMEOUT, async {
             loop {
                 match listener.accept().await {
@@ -120,9 +136,6 @@ pub async fn start_port_forward(client: &Client, req: &PortForwardRequest) -> cr
                 IDLE_TIMEOUT.as_secs()
             );
         }
-
-        // Decrement active-forward counter when the task ends
-        ACTIVE_FORWARDS.fetch_sub(1, Ordering::SeqCst);
     });
 
     Ok(actual_port)
@@ -152,6 +165,8 @@ async fn handle_connection(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static COUNTER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn port_forward_request_serializes() {
@@ -196,5 +211,29 @@ mod tests {
     fn active_forward_counter_starts_at_zero() {
         // Note: other tests may run concurrently, so we just verify the function works.
         let _ = active_forward_count();
+    }
+
+    #[test]
+    fn active_forward_guard_acquire_increments_and_drop_decrements() {
+        let _lock = COUNTER_TEST_LOCK.lock().unwrap();
+        ACTIVE_FORWARDS.store(0, Ordering::SeqCst);
+
+        let guard = ActiveForwardGuard::acquire().unwrap();
+        assert_eq!(active_forward_count(), 1);
+
+        drop(guard);
+        assert_eq!(active_forward_count(), 0);
+    }
+
+    #[test]
+    fn active_forward_guard_rejects_at_limit_without_incrementing() {
+        let _lock = COUNTER_TEST_LOCK.lock().unwrap();
+        ACTIVE_FORWARDS.store(MAX_FORWARDS, Ordering::SeqCst);
+
+        let err = ActiveForwardGuard::acquire().unwrap_err();
+        assert!(err.to_string().contains("Port forward limit reached"));
+        assert_eq!(active_forward_count(), MAX_FORWARDS);
+
+        ACTIVE_FORWARDS.store(0, Ordering::SeqCst);
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ graph TB
 | `kubeconfig.rs` | Parse `~/.kube/config`, list contexts with auth metadata |
 | `node_ops.rs` | Cordon, uncordon, drain, add/remove taints |
 | `dynamic.rs` | Generic dynamic resource apply/delete for arbitrary GVKs |
-| `helm.rs` | Helm release listing, history, values (with sensitive key redaction), rollback |
+| `helm.rs` | Helm release listing, history, values (sensitive key redaction; raw reveal denied and audited), rollback |
 | `metrics.rs` | Pod and node metrics via the Metrics API |
 | `crd.rs` | CRD discovery and instance listing |
 | `secrets.rs` | On-demand secret fetch with payload redaction |
@@ -107,7 +107,7 @@ graph TB
 | `resolve.rs` | AKS identity resolution: saved preferences -> Azure CLI (`az aks list`) -> FQDN hints. Resolves subscription, resource group, and cluster name. |
 | `error.rs` | `AzureError` variants: `NotFound`, `Conflict`, `Api { status, code, message }`, `Identity`, `Http`, `Json`, `CliNotFound`, `CliFailed` |
 
-**Desktop (`apps/desktop`)** — Tauri 2 shell exposing 66 IPC commands across nine groups: context/connection (7), Azure ARM/AKS (18), resource queries (8), secrets (2), Helm (4), namespaces (3), logs (3), resource actions/node ops (15), exec/portforward/metrics (6). State is held in `AppState` (SQLite store + connection state + watch handle).
+**Desktop (`apps/desktop`)** — Tauri 2 shell exposing 60+ IPC commands across context/connection, Azure ARM/AKS, resource queries, secrets, Helm, namespaces, logs, resource actions/node ops, exec, port-forward, and metrics. State is held in `AppState` (SQLite store + connection state + watcher supervisor handle).
 
 **Frontend (`apps/web`)** — SvelteKit frontend (Svelte 5 runes). 25 components, 39 routes, Svelte writable/derived stores for context, namespace, and connection state. `api.ts` wraps Tauri command invocations for the desktop shell.
 
@@ -189,7 +189,8 @@ sequenceDiagram
 ### Key Design Decisions
 
 - **SQLite as cache** — All K8s objects are stored as JSON blobs in a single `resources` table. The UI reads from SQLite, never directly from the API server. This decouples watch latency from UI responsiveness.
-- **Scoped watchers** — Watchers are started per-namespace when a user connects. Switching namespaces (`set_namespace`) aborts existing watches and spawns new ones.
+- **Scoped watchers** — Watchers are started per-namespace when a user connects. Switching namespaces (`set_namespace`), reconnecting, or disconnecting cancels the current watcher supervisor and spawns a fresh one when needed.
+- **Watcher supervisor ownership** — Desktop state stores a `WatchTaskHandle`, not a bare `JoinHandle`. The handle owns a shared `CancellationToken` plus the state-forwarder, cluster-scoped, namespaced, and pod watcher tasks. `cancel()` and `Drop` both cancel the token and abort owned tasks so replacement or external abort cannot orphan auxiliary watchers.
 - **Semaphore-limited LIST** — At most 3 concurrent LIST operations to avoid overwhelming the API server during initial sync.
 - **Event-driven UI** — Connection state changes are pushed to the frontend via Tauri events, not polled.
 - **Azure ARM is separate** — AKS management operations use the Azure ARM REST API through `crates/azure`, not the Kubernetes API. This keeps the K8s engine decoupled from Azure-specific logic.
@@ -339,8 +340,10 @@ CREATE INDEX IF NOT EXISTS idx_resources_gvk_ns
 - [x] **Server-side dry-run** — `apply_resource` supports `dry_run: bool` for safe preview before mutation.
 - [x] **Database isolation** — SQLite store at `~/.telescope/resources.db` (per-user home directory).
 - [x] **Secrets redacted by default** — secret payload fields (`data`, `stringData`, `binaryData`, `last-applied-configuration`) are replaced with `●●●●●●●●` before serialization.
-- [x] **Helm values redacted** — sensitive keys (`password`, `token`, `secret`, `apiKey`, `connectionString`, `private_key`, `client_secret`, `access_key`, `credentials`, `auth`, and variants) are recursively redacted in Helm release values.
-- [x] **Audit logging** — JSONL audit entries for destructive operations (see Audit section below).
+- [x] **Helm values redacted and reveal denied** — sensitive keys (`password`, `token`, `secret`, `apiKey`, `connectionString`, `private_key`, `client_secret`, `access_key`, `credentials`, `auth`, and variants) are recursively redacted in Helm release values. Raw reveal requests are denied before Helm values are fetched, audited as denied attempts, and returned to the UI as sanitized errors.
+- [x] **Cached GVK allowlist** — cached resource IPC commands validate `gvk` arguments against `ALL_WATCHED_GVKS` before `ResourceStore::list`, `ResourceStore::get`, or cached count queries. Unsupported cached resource types return a generic sanitized error.
+- [x] **User-facing error sanitization** — Helm command failures and frontend IPC errors redact local paths, raw command output, and secret-shaped values before reaching UI notifications or console logs.
+- [x] **Audit logging** — JSONL audit entries for destructive and sensitive operations (see Audit section below).
 - [x] **File permissions** — audit log and SQLite DB created with `0600` permissions on Unix.
 - [x] **Azure ARM auth** — `DefaultAzureCredential` for ARM API access; no hardcoded secrets (see Azure ARM Security section below).
 
@@ -419,14 +422,14 @@ CREATE INDEX IF NOT EXISTS idx_resources_gvk_ns
 | Command | Description |
 |---------|-------------|
 | `get_pods` | List pods |
-| `get_resources` | List resources by GVK |
+| `get_resources` | List resources by allowlisted cached GVK |
 | `get_events` | List/filter events |
-| `get_resource_counts` | Resource counts by GVK |
+| `get_resource_counts` | Resource counts for allowlisted cached GVKs |
 | `count_resources` | Count resources |
 | `search_resources` | Search resources by name |
 | `list_dynamic_resources` | List resources for a dynamic GVK |
 | `get_dynamic_resource` | Get a single dynamic resource |
-| `get_resource` | Get single resource |
+| `get_resource` | Get single resource by allowlisted cached GVK |
 | `get_secrets` | List secrets (on-demand, not cached) |
 | `get_secret` | Get single secret (redacted) |
 
@@ -436,8 +439,9 @@ CREATE INDEX IF NOT EXISTS idx_resources_gvk_ns
 |---------|-------------|
 | `list_helm_releases` | List releases across namespaces |
 | `get_helm_release_history` | Release revision history |
-| `get_helm_release_values` | Release values (redacted unless revealed) |
+| `get_helm_release_values` | Release values with sensitive keys redacted; raw reveal requests are denied and audited |
 | `helm_rollback` | Rollback to a previous revision |
+| `helm_uninstall` | Uninstall a release with audit logging and sanitized command errors |
 
 ### Namespaces
 
@@ -504,7 +508,7 @@ Each `AuditEntry` contains: `timestamp`, `actor`, `context`, `namespace`, `actio
 |----------|-----------|
 | Connection | `connect_to_context`, `disconnect` |
 | AKS node pools | `scale_aks_node_pool`, `update_aks_autoscaler`, `create_aks_node_pool`, `delete_aks_node_pool` |
-| Helm | `helm_rollback` |
+| Helm | `helm_rollback`, `helm_uninstall`, denied `helm_values_reveal` attempts |
 | Namespaces | `create_namespace`, `delete_namespace` |
 | Resources | `apply_dynamic_resource`, `delete_dynamic_resource`, `scale_resource`, `delete_resource`, `apply_resource`, `rollout_restart` |
 | Node ops | `cordon_node`, `uncordon_node`, `drain_node`, `add_node_taint`, `remove_node_taint` |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -14,7 +14,7 @@ description: "Full feature matrix for Telescope — Kubernetes, Azure ARM, Helm,
 |---|---|
 | Full cluster connection and context management | Discover kubeconfig contexts, connect/disconnect, track connection state, and switch namespaces |
 | Search and settings | Search cached resources quickly and manage user-facing preferences from the UI |
-| Audit logging | Record key local actions for traceability in the desktop app |
+| Audit logging | Record key local actions and denied sensitive reveal attempts for traceability in the desktop app |
 
 ## Kubernetes Operations
 
@@ -24,7 +24,7 @@ description: "Full feature matrix for Telescope — Kubernetes, Azure ARM, Helm,
 | CRD browsing | Explore installed CustomResourceDefinitions and dynamic resources with schema/details support |
 | Pod operations | View logs, exec into containers, and start port-forwards |
 | Resource actions | Scale workloads, delete resources, create namespaces, apply YAML, and trigger rollout operations with safety checks |
-| Helm release management | List releases, inspect history/values, and support Helm rollback and uninstall workflows |
+| Helm release management | List releases, inspect history and redacted values, and support Helm rollback and uninstall workflows |
 | Node management and metrics | Inspect nodes plus pod and node metrics for cluster health |
 
 ## Azure ARM Management Plane

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -19,9 +19,11 @@ description: "Threat model, secret handling, audit logging, and credential manag
 - **Desktop connection state is explicit:** the shared `ConnectionState` machine tracks `Disconnected`, `Connecting`, `Syncing`, `Ready`, `Degraded`, `Error`, and `Backoff`, which lets the UI surface authentication/connection failures clearly.
 - **Secrets are redacted by default:** secret list/detail reads bypass the shared cache and redact `data`, `stringData`, `binaryData`, and the `kubectl.kubernetes.io/last-applied-configuration` annotation. The redaction placeholder is `●●●●●●●●`.
 - **Helper execution is pinned to trusted binaries:** kubeconfig `exec` auth helpers, Azure CLI fallback calls, and Helm rollback/uninstall only run when Telescope can resolve them to a trusted installation path. Relative or unknown helper commands are blocked before execution.
-- **Helm values are redacted:** sensitive keys (`password`, `passwd`, `secret`, `token`, `apikey`, `api_key`, `apiKey`, `connectionstring`, `connection_string`, `connectionString`, `private_key`, `client_secret`, `access_key`, `secret_key`, `credentials`, `auth`) are recursively redacted in Helm release values. Reveal requires an explicit user action with a UI warning.
+- **Helm values are redacted and raw reveal is denied:** sensitive keys (`password`, `passwd`, `secret`, `token`, `apikey`, `api_key`, `apiKey`, `connectionstring`, `connection_string`, `connectionString`, `private_key`, `client_secret`, `access_key`, `secret_key`, `credentials`, `auth`) are recursively redacted in Helm release values. Requests to reveal raw values are denied before values are fetched, audited as denied attempts, and returned as sanitized errors.
 - **SQLite cache redaction is broader than v1.0.0:** cached resources now redact Pod/workload `env`, `command`, and `args`; annotation values; ConfigMap payloads; webhook client URLs / CA bundles; and secret-shaped fields before they are written to `resources.db`.
-- **Audit logging covers destructive operations:** the engine writes JSONL audit entries for connection lifecycle, AKS node pool operations, Helm rollbacks, namespace create/delete, resource apply/delete/scale, rollout restarts, node cordon/uncordon/drain/taint, and exec commands.
+- **Cached resource reads are allowlisted:** cached `gvk` arguments are validated against the watched GVK registry before the desktop command queries SQLite. Unsupported cached resource types return a generic sanitized error instead of echoing caller input.
+- **User-facing command/API errors are sanitized:** Helm command failures and frontend IPC errors remove local paths, raw command output, and secret-shaped values before they reach notifications or console logs.
+- **Audit logging covers destructive and sensitive operations:** the engine writes JSONL audit entries for connection lifecycle, AKS node pool operations, Helm rollbacks, Helm uninstall, denied Helm values reveal attempts, namespace create/delete, resource apply/delete/scale, rollout restarts, node cordon/uncordon/drain/taint, and exec commands.
 - **Sensitive local files are permissioned on Unix:** Telescope creates `~/.telescope/audit.log` and `~/.telescope/resources.db` with restrictive `0600` permissions.
 
 ## Kubeconfig & credentials
@@ -56,8 +58,15 @@ description: "Threat model, secret handling, audit logging, and credential manag
 ## Secrets
 - Secret list/detail APIs intentionally fetch secrets on demand instead of storing them in the shared watched-resource cache.
 - The engine redacts secret payload fields before serializing them for the UI.
-- The UI prevents naïve re-apply of masked YAML and warns when revealing unredacted values.
-- Per-key reveal flows, reveal timeouts, and secure local persistence are still future work.
+- The UI treats redacted secret YAML as masked data and prevents naive re-apply of masked content.
+- Per-key secret reveal flows, reveal timeouts, and secure local persistence are still future work.
+
+## Helm release values
+- Normal Helm values requests (`reveal: false` or omitted) fetch release values and recursively redact sensitive keys before returning YAML to the UI.
+- Raw Helm values reveal requests (`reveal: true`) are denied before Telescope creates a Kubernetes client or fetches Helm values.
+- Denied reveal attempts write an audit entry with action `helm_values_reveal` and result `denied`.
+- The frontend wrapper no longer accepts or sends a reveal flag, and the Helm detail page no longer renders plaintext reveal controls.
+- A nonce challenge or scoped plaintext reveal policy is future/proposed only. Any future plaintext reveal must require short-lived nonce verification before an approved audit entry is written and scoped plaintext values are returned. The current implementation has no plaintext Helm values return path.
 
 ## Actions safety
 - The connection-state machine gives the UI explicit feedback for connect/auth/backoff/error flows instead of silently failing.
@@ -72,9 +81,15 @@ description: "Threat model, secret handling, audit logging, and credential manag
   - Diff preview everywhere.
   - Universal server-side dry-run enforcement.
 
+## User-facing error sanitization
+- Command handlers should return user-safe categories such as not found, permission denied, timeout, command unavailable, or command failed.
+- Public errors must not include helper binary paths, kubeconfig paths, raw `stdout`/`stderr`, tokens, passwords, or secret-shaped key/value material.
+- Frontend IPC wrappers sanitize thrown errors and listener messages before showing notifications or logging command-level failures.
+- Detailed diagnostics belong in explicit debug or audit channels, not default UI text or console output.
+
 ## Audit logging
 - `crates/engine/src/audit.rs` appends structured JSONL entries with: `timestamp`, `actor`, `context`, `namespace`, `action`, `resource_type`, `resource_name`, `result`, `detail`.
-- **Audited operations:** cluster connect/disconnect, AKS node pool scale/create/delete/autoscaler, Helm rollback, namespace create/delete, resource apply/delete/scale, rollout restart, node cordon/uncordon/drain/taint add/remove, exec commands.
+- **Audited operations:** cluster connect/disconnect, AKS node pool scale/create/delete/autoscaler, Helm rollback, Helm uninstall, denied Helm values reveal attempts, namespace create/delete, resource apply/delete/scale, rollout restart, node cordon/uncordon/drain/taint add/remove, exec commands.
 - Audit log location: `~/.telescope/audit.log` (permissions `0600` on Unix).
 
 ## Plugins
@@ -90,3 +105,4 @@ description: "Threat model, secret handling, audit logging, and credential manag
 - RBAC capability pre-checks before every mutation.
 - Diff preview for all apply operations.
 - Secret reveal workflows with timeouts and secure local persistence.
+- Scoped Helm plaintext reveal policy, if product requirements ever justify one; current behavior denies plaintext reveal.

--- a/docs/diagrams/architecture.md
+++ b/docs/diagrams/architecture.md
@@ -2,6 +2,11 @@
 
 These standalone diagrams summarize the current Telescope v1.0.0 desktop architecture. They are grounded in the current code layout in `apps/web`, `apps/desktop`, `crates/engine`, `crates/azure`, and `crates/core`.
 
+## Hardening Sprint Diagrams
+
+- [Watcher supervisor lifecycle](watcher-supervisor.svg)
+- [Helm values audit and error-handling flow](helm-values-audit-flow.svg)
+
 ## 1. System Context Diagram
 
 The Tauri desktop application packages the frontend and connects to shared Rust crates for both Kubernetes API access and Azure ARM management.

--- a/docs/diagrams/helm-values-audit-flow.svg
+++ b/docs/diagrams/helm-values-audit-flow.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="920" viewBox="0 0 1120 920" role="img" aria-labelledby="title desc">
+  <title id="title">Helm Values Audit and Error-Handling Flow</title>
+  <desc id="desc">Current Telescope behavior: redacted Helm values are returned for normal requests, while raw reveal requests are denied, audited, and returned as sanitized errors. A separate lower lane shows the proposed nonce-gated plaintext policy for any future reveal support.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#334155" />
+    </marker>
+    <style>
+      .bg { fill: #f8fafc; }
+      .box { fill: #ffffff; stroke: #334155; stroke-width: 2; rx: 8; }
+      .safe { fill: #dcfce7; stroke: #15803d; }
+      .deny { fill: #fee2e2; stroke: #b91c1c; }
+      .audit { fill: #ede9fe; stroke: #7c3aed; }
+      .future { fill: #e0f2fe; stroke: #0369a1; }
+      .decision { fill: #fef9c3; stroke: #a16207; }
+      .text { font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 18px; fill: #0f172a; }
+      .small { font-size: 15px; fill: #334155; }
+      .title { font-size: 28px; font-weight: 700; }
+      .label { font-size: 16px; font-weight: 700; fill: #334155; }
+      .arrow { stroke: #334155; stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
+      .dash { stroke-dasharray: 8 6; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="1120" height="920" />
+  <text class="text title" x="40" y="54">Helm Values Audit and Error-Handling Flow</text>
+  <text class="text small" x="40" y="84">No current path returns plaintext Helm values.</text>
+
+  <rect class="box" x="55" y="130" width="240" height="100" />
+  <text class="text label" x="82" y="166">Frontend API</text>
+  <text class="text small" x="82" y="194">Requests values</text>
+  <text class="text small" x="82" y="216">without a reveal flag</text>
+
+  <rect class="box" x="385" y="125" width="300" height="110" />
+  <text class="text label" x="416" y="160">get_helm_release_values</text>
+  <text class="text small" x="416" y="188">validates namespace/name</text>
+  <text class="text small" x="416" y="212">checks reveal argument</text>
+
+  <path class="box decision" d="M 535 292 L 685 372 L 535 452 L 385 372 Z" />
+  <text class="text label" x="474" y="365">reveal == true?</text>
+  <text class="text small" x="486" y="392">IPC argument check</text>
+
+  <rect class="box safe" x="75" y="515" width="300" height="115" />
+  <text class="text label" x="106" y="550">Normal request</text>
+  <text class="text small" x="106" y="578">fetch Helm values</text>
+  <text class="text small" x="106" y="602">recursively redact keys</text>
+  <text class="text small" x="106" y="624">return redacted YAML</text>
+
+  <rect class="box deny" x="745" y="300" width="300" height="115" />
+  <text class="text label" x="776" y="335">Denied reveal request</text>
+  <text class="text small" x="776" y="363">no Kubernetes client</text>
+  <text class="text small" x="776" y="387">no Helm values fetch</text>
+  <text class="text small" x="776" y="409">no plaintext return</text>
+
+  <rect class="box audit" x="745" y="475" width="300" height="105" />
+  <text class="text label" x="776" y="510">Audit entry</text>
+  <text class="text small" x="776" y="538">action: helm_values_reveal</text>
+  <text class="text small" x="776" y="562">result: denied</text>
+
+  <rect class="box deny" x="745" y="610" width="300" height="70" />
+  <text class="text label" x="776" y="642">Sanitized error</text>
+  <text class="text small" x="776" y="666">safe denial message to UI</text>
+
+  <path class="arrow" d="M 295 180 L 385 180" />
+  <path class="arrow" d="M 535 235 L 535 292" />
+  <path class="arrow" d="M 385 372 C 270 394 225 455 225 515" />
+  <path class="arrow" d="M 685 372 L 745 358" />
+  <path class="arrow" d="M 895 415 L 895 475" />
+  <path class="arrow" d="M 895 580 L 895 610" />
+  <path class="arrow dash" d="M 745 645 C 520 680 250 675 175 630" />
+
+  <text class="text small" x="316" y="392">No</text>
+  <text class="text small" x="705" y="350">Yes</text>
+  <text class="text small" x="365" y="708">Current implementation stops here: reveal requests are denied, audited, and sanitized.</text>
+
+  <text class="text label" x="75" y="750">Future/proposed plaintext policy, not implemented in this branch</text>
+  <rect class="box future dash" x="75" y="775" width="210" height="80" />
+  <text class="text label" x="105" y="807">Reveal request</text>
+  <text class="text small" x="105" y="832">requires policy gate</text>
+
+  <rect class="box future dash" x="325" y="775" width="220" height="80" />
+  <text class="text label" x="355" y="807">Nonce challenge</text>
+  <text class="text small" x="355" y="832">short-lived proof</text>
+
+  <rect class="box audit dash" x="585" y="775" width="220" height="80" />
+  <text class="text label" x="615" y="807">Audit log</text>
+  <text class="text small" x="615" y="832">approved reveal event</text>
+
+  <rect class="box future dash" x="845" y="775" width="220" height="80" />
+  <text class="text label" x="875" y="807">Plaintext return</text>
+  <text class="text small" x="875" y="832">scoped and time-bound</text>
+
+  <path class="arrow dash" d="M 285 815 L 325 815" />
+  <path class="arrow dash" d="M 545 815 L 585 815" />
+  <path class="arrow dash" d="M 805 815 L 845 815" />
+  <text class="text small" x="75" y="890">Any future plaintext reveal must include nonce verification before audit logging and must return only scoped, explicit plaintext values.</text>
+</svg>

--- a/docs/diagrams/watcher-supervisor.svg
+++ b/docs/diagrams/watcher-supervisor.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="720" viewBox="0 0 1120 720" role="img" aria-labelledby="title desc">
+  <title id="title">Watcher Supervisor Lifecycle</title>
+  <desc id="desc">Telescope desktop watcher supervisor owns a shared cancellation token and all watcher tasks, then cancels and aborts them on reconnect, disconnect, namespace switch, or drop.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#334155" />
+    </marker>
+    <style>
+      .bg { fill: #f8fafc; }
+      .box { fill: #ffffff; stroke: #334155; stroke-width: 2; rx: 8; }
+      .owner { fill: #e0f2fe; stroke: #0369a1; }
+      .token { fill: #dcfce7; stroke: #15803d; }
+      .task { fill: #fef9c3; stroke: #a16207; }
+      .cleanup { fill: #fee2e2; stroke: #b91c1c; }
+      .text { font-family: Inter, ui-sans-serif, system-ui, sans-serif; font-size: 18px; fill: #0f172a; }
+      .small { font-size: 15px; fill: #334155; }
+      .title { font-size: 28px; font-weight: 700; }
+      .label { font-size: 16px; font-weight: 700; fill: #334155; }
+      .arrow { stroke: #334155; stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
+      .dash { stroke-dasharray: 8 6; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="1120" height="720" />
+  <text class="text title" x="40" y="54">Watcher Supervisor Lifecycle</text>
+  <text class="text small" x="40" y="84">AppState owns one supervisor per active connection or namespace scope.</text>
+
+  <rect class="box" x="40" y="130" width="230" height="110" />
+  <text class="text label" x="65" y="166">AppState</text>
+  <text class="text small" x="65" y="194">watch_handle:</text>
+  <text class="text small" x="65" y="218">Option&lt;WatchTaskHandle&gt;</text>
+
+  <rect class="box owner" x="360" y="110" width="330" height="150" />
+  <text class="text label" x="392" y="148">WatchTaskHandle owner</text>
+  <text class="text small" x="392" y="178">- shared CancellationToken</text>
+  <text class="text small" x="392" y="202">- all watcher JoinHandles</text>
+  <text class="text small" x="392" y="226">- cancel() and Drop cleanup</text>
+
+  <rect class="box token" x="430" y="320" width="260" height="86" />
+  <text class="text label" x="462" y="354">CancellationToken</text>
+  <text class="text small" x="462" y="382">Shared by every task</text>
+
+  <rect class="box task" x="60" y="500" width="220" height="90" />
+  <text class="text label" x="84" y="536">State forwarder</text>
+  <text class="text small" x="84" y="562">Tauri state events</text>
+
+  <rect class="box task" x="330" y="500" width="220" height="90" />
+  <text class="text label" x="354" y="536">Pod watcher</text>
+  <text class="text small" x="354" y="562">Primary LIST/WATCH</text>
+
+  <rect class="box task" x="600" y="500" width="220" height="90" />
+  <text class="text label" x="624" y="536">Namespaced watchers</text>
+  <text class="text small" x="624" y="562">Workloads, RBAC, policy</text>
+
+  <rect class="box task" x="870" y="500" width="210" height="90" />
+  <text class="text label" x="894" y="536">Cluster watchers</text>
+  <text class="text small" x="894" y="562">Nodes, classes, webhooks</text>
+
+  <rect class="box cleanup" x="790" y="125" width="285" height="135" />
+  <text class="text label" x="818" y="162">Lifecycle triggers</text>
+  <text class="text small" x="818" y="190">reconnect / disconnect</text>
+  <text class="text small" x="818" y="214">namespace switch</text>
+  <text class="text small" x="818" y="238">replacement drop / abort</text>
+
+  <rect class="box cleanup" x="790" y="320" width="285" height="86" />
+  <text class="text label" x="818" y="354">Cleanup action</text>
+  <text class="text small" x="818" y="382">cancel token, abort tasks</text>
+
+  <path class="arrow" d="M 270 185 L 360 185" />
+  <path class="arrow" d="M 525 260 L 545 320" />
+  <path class="arrow" d="M 790 190 L 690 190" />
+  <path class="arrow" d="M 932 260 L 932 320" />
+  <path class="arrow" d="M 790 363 L 690 363" />
+  <path class="arrow dash" d="M 480 406 C 330 430 230 455 170 500" />
+  <path class="arrow dash" d="M 540 406 C 500 440 465 466 440 500" />
+  <path class="arrow dash" d="M 610 406 C 660 438 695 466 710 500" />
+  <path class="arrow dash" d="M 675 390 C 815 420 925 455 975 500" />
+
+  <text class="text small" x="300" y="174">stores owner</text>
+  <text class="text small" x="712" y="180">cancel()</text>
+  <text class="text small" x="708" y="350">Drop fallback</text>
+  <text class="text small" x="365" y="655">Every watcher uses tokio::select! on token cancellation.</text>
+</svg>

--- a/docs/plans/2026-05-10-architecture-vulnerability-review.md
+++ b/docs/plans/2026-05-10-architecture-vulnerability-review.md
@@ -1,0 +1,48 @@
+# Architecture Vulnerability Review
+
+Branch: `review/architecture-vulnerability-2026-05-10`
+
+Date: 2026-05-10
+
+Scope: Branch-local tracking report for verified architecture and security findings only. This report intentionally excludes rejected or unverified findings.
+
+## Validation Summary
+
+- Rust validation command reached the test phase, so `cargo fmt --all -- --check` and `cargo clippy --workspace --exclude telescope-desktop --all-targets --all-features -- -D warnings` passed.
+- `cargo test --workspace --exclude telescope-desktop --all-features` failed in `resolve::tests::resolve_az_binary_path_accepts_trusted_binary_name`, panicking at [crates/azure/src/resolve.rs:434](../../crates/azure/src/resolve.rs#L434). The failing test body is at [crates/azure/src/resolve.rs:426-434](../../crates/azure/src/resolve.rs#L426-L434).
+- `./scripts/pnpm.sh -C apps/web test` passed: 8 files, 65 tests.
+- `./scripts/pnpm.sh -C apps/web build` passed.
+- `./scripts/pnpm.sh -C apps/web e2e` passed: 41 tests in 38.6s.
+- Overall status: frontend validation is green, but the full gate is red until the Rust test failure is fixed and rerun.
+
+## Findings
+
+| ID | Severity | Finding | Evidence | Impact | Recommended Remediation |
+| --- | --- | --- | --- | --- | --- |
+| F-01 | High | Rust build health is red due to a failing Azure trusted-binary resolver test. | [crates/azure/src/resolve.rs:426-434](../../crates/azure/src/resolve.rs#L426-L434) | CI/local validation cannot be considered green. Trusted binary path hardening has a regression or a test fixture mismatch. | Update the resolver or test fixture so the test binary is accepted only through the intended trusted-list seam, then rerun the Rust gate. |
+| F-02 | High | Watcher lifecycle can leak auxiliary watcher tasks on reconnect, disconnect, or namespace switch. | Watch reset call sites: [apps/desktop/src-tauri/src/main.rs:995-996](../../apps/desktop/src-tauri/src/main.rs#L995-L996), [apps/desktop/src-tauri/src/main.rs:1074](../../apps/desktop/src-tauri/src/main.rs#L1074), [apps/desktop/src-tauri/src/main.rs:1130](../../apps/desktop/src-tauri/src/main.rs#L1130). Watch task implementation: [apps/desktop/src-tauri/src/main.rs:1835-2003](../../apps/desktop/src-tauri/src/main.rs#L1835-L2003), especially aux tasks at [apps/desktop/src-tauri/src/main.rs:1853](../../apps/desktop/src-tauri/src/main.rs#L1853) and [apps/desktop/src-tauri/src/main.rs:1870-1988](../../apps/desktop/src-tauri/src/main.rs#L1870-L1988), main-task cleanup at [apps/desktop/src-tauri/src/main.rs:1995-1999](../../apps/desktop/src-tauri/src/main.rs#L1995-L1999), and stored handle at [apps/desktop/src-tauri/src/main.rs:2002-2003](../../apps/desktop/src-tauri/src/main.rs#L2002-L2003). | `abort_watch` aborts only the main `JoinHandle`; if it is aborted externally, the main task never reaches its cleanup block, leaving `state_forwarder` and auxiliary watchers alive. | Use a shared `CancellationToken` or a watch supervisor/RAII guard that owns and aborts all child tasks when the watch handle is dropped or aborted. |
+| F-03 | High | Helm values reveal returns plaintext sensitive values without backend authorization or audit. | Backend reveal handler: [apps/desktop/src-tauri/src/main.rs:843-860](../../apps/desktop/src-tauri/src/main.rs#L843-L860). Frontend API wrapper: [apps/web/src/lib/api.ts:485-488](../../apps/web/src/lib/api.ts#L485-L488). UI confirmation path: [apps/web/src/routes/helm/[namespace]/[name]/+page.svelte:101-107](../../apps/web/src/routes/helm/%5Bnamespace%5D/%5Bname%5D/+page.svelte#L101-L107) and [apps/web/src/routes/helm/[namespace]/[name]/+page.svelte:220-232](../../apps/web/src/routes/helm/%5Bnamespace%5D/%5Bname%5D/+page.svelte#L220-L232). Audited rollback contrast: [apps/desktop/src-tauri/src/main.rs:880-891](../../apps/desktop/src-tauri/src/main.rs#L880-L891). | Any packaged frontend path or injected `invoke` call can request `reveal: true`. The UI shows a warning and confirmation, but the backend does not audit the reveal. | Audit every reveal. Consider command-level authorization, a confirmation nonce, or scoped policy before returning unredacted values. |
+| F-04 | Medium | Backend and frontend propagate raw command errors and paths. | Helm command error propagation: [crates/engine/src/helm.rs:437-459](../../crates/engine/src/helm.rs#L437-L459) and [crates/engine/src/helm.rs:474-478](../../crates/engine/src/helm.rs#L474-L478). Frontend API error logging/detail handling: [apps/web/src/lib/api.ts:35-43](../../apps/web/src/lib/api.ts#L35-L43) and [apps/web/src/lib/api.ts:70-75](../../apps/web/src/lib/api.ts#L70-L75). | Helm paths, `stderr`, `stdout`, and backend details can be returned to the UI and console logs, exposing local paths or sensitive command output. | Sanitize user-facing errors and keep detailed diagnostics behind a debug or audit channel. |
+| F-05 | Medium | Port-forward active counter is not panic/abort safe. | Counter and task lifecycle: [crates/engine/src/portforward.rs:55-62](../../crates/engine/src/portforward.rs#L55-L62) and [crates/engine/src/portforward.rs:90-125](../../crates/engine/src/portforward.rs#L90-L125). | The active counter increments before spawning and decrements only at normal task exit. Panic or abort of the outer forwarding task can leave the counter elevated and eventually deny new forwards. | Introduce an RAII guard or supervised task wrapper that decrements on drop/cancellation. |
+| F-06 | Medium | Security and supply-chain scanning is absent from workflows. | CI coverage: [.github/workflows/ci.yml:22-28](../../.github/workflows/ci.yml#L22-L28), [.github/workflows/ci.yml:42-63](../../.github/workflows/ci.yml#L42-L63), [.github/workflows/ci.yml:65-87](../../.github/workflows/ci.yml#L65-L87). Workflow guidance notes no Dependabot/CodeQL/audit checks at [.github/workflows/AGENTS.md:99](../../.github/workflows/AGENTS.md#L99). | Rust/npm vulnerable dependencies and code scanning regressions are not caught in CI. | Add Dependabot, CodeQL or `cargo-audit`/`cargo-deny`, and a `pnpm audit` policy suited for release gates. |
+| F-07 | Medium | K3D integration tests are not PR-gated. | Integration workflow triggers and jobs: [.github/workflows/integration.yml:3-11](../../.github/workflows/integration.yml#L3-L11) and [.github/workflows/integration.yml:49-52](../../.github/workflows/integration.yml#L49-L52). | Real-cluster watcher/resource regressions can merge via PR and only run on `main` push or manual dispatch. | Add a `pull_request` trigger with path filters, or require a nightly/merge-queue gate for k3d integration. |
+| F-08 | Low | Resource cache read commands accept raw GVK strings without allowlist validation. | Raw GVK cache reads: [apps/desktop/src-tauri/src/main.rs:611-622](../../apps/desktop/src-tauri/src/main.rs#L611-L622) and [apps/desktop/src-tauri/src/main.rs:773-785](../../apps/desktop/src-tauri/src/main.rs#L773-L785). Contrast `search_resources` iterating watched GVKs at [apps/desktop/src-tauri/src/main.rs:688-689](../../apps/desktop/src-tauri/src/main.rs#L688-L689). | No SQL injection was observed, but arbitrary GVK lookups expose internal cache shape and weaken command contracts. | Validate GVK inputs against the watched/dynamic-resource registry before querying. |
+
+## No-Finding Notes
+
+- Kubernetes Secret reads are redacted before content is returned. Evidence: [crates/engine/src/secrets.rs:35-47](../../crates/engine/src/secrets.rs#L35-L47), [crates/engine/src/secrets.rs:64-85](../../crates/engine/src/secrets.rs#L64-L85), and tests at [crates/engine/src/secrets.rs:100-132](../../crates/engine/src/secrets.rs#L100-L132).
+- AI Insights API keys are session-only in the frontend and sanitized from visible messages. Evidence: [apps/web/src/routes/insights/+page.svelte:51-65](../../apps/web/src/routes/insights/+page.svelte#L51-L65) and [apps/web/src/lib/api.ts:577-604](../../apps/web/src/lib/api.ts#L577-L604).
+- `apps/web/build` is ignored and not tracked, so committed build output should not be listed as a finding.
+- Playwright `forbidOnly` is enforced in CI via [apps/web/playwright.config.ts:9](../../apps/web/playwright.config.ts#L9).
+- Windows/macOS bundle artifact validation exists in [.github/workflows/build-desktop.yml:52-70](../../.github/workflows/build-desktop.yml#L52-L70) and [.github/workflows/build-desktop.yml:119-127](../../.github/workflows/build-desktop.yml#L119-L127). There is still no runtime launch smoke test.
+
+## Recommended Remediation Order
+
+1. Fix the Azure trusted-binary resolver test failure and rerun the Rust gate so the branch has a green baseline.
+2. Rework watcher lifecycle ownership so main and auxiliary watcher tasks are cancelled together on reconnect, disconnect, namespace switch, and external abort.
+3. Add backend audit and stronger authorization/confirmation semantics for Helm values reveal before returning plaintext values.
+4. Make port-forward accounting cancellation safe with an RAII guard or supervised task wrapper.
+5. Sanitize Helm and backend command errors before they reach user-facing UI or console paths.
+6. Add supply-chain and code scanning gates appropriate for Rust and pnpm dependencies.
+7. Add PR or merge-queue coverage for k3d integration tests.
+8. Validate raw cache GVK reads against the watched/dynamic resource registry.

--- a/docs/plans/2026-05-10-hardening-pr.md
+++ b/docs/plans/2026-05-10-hardening-pr.md
@@ -1,0 +1,64 @@
+# security: architectural hardening and vulnerability remediation (Sprint 2026-05-10)
+
+Target branch: `main`
+Source branch: `review/architecture-vulnerability-2026-05-10`
+
+## Executive Summary
+
+This PR closes the 2026-05-10 architecture vulnerability review by replacing fragile task-tail cleanup with ownership-based safety, tightening sensitive data boundaries, and adding release-gate coverage for dependency and integration regressions. The theme across the sprint is Security by Design: RAII guards own cleanup, supervisors own task lifecycles, sensitive operations produce mandatory audit trails, and user-facing errors expose safe categories instead of raw internals.
+
+The largest behavior correction is Helm values handling. Telescope no longer exposes a plaintext Helm values reveal path. Normal values requests return recursively redacted YAML, while `reveal: true` requests are denied before values are fetched, logged as denied audit attempts, and surfaced as sanitized errors.
+
+## Detailed Breakdown
+
+### Memory/Task Safety
+
+- **F-02 - Watcher Lifecycle Auxiliary Task Leak:** Replaced the stored raw watcher `JoinHandle` with `WatchTaskHandle`, an owner that contains the shared `CancellationToken` and every watcher/forwarder task handle. Reconnect, disconnect, namespace switch, replacement, and drop paths now cancel the token and abort owned tasks together.
+- **F-05 - Port-forward Active Counter Panic/Abort Safety:** Added `ActiveForwardGuard` with atomic acquisition and `Drop` cleanup so port-forward slots are released on normal completion, early return, panic unwinding, and task abort/drop.
+
+### API & Data Security
+
+- **F-03 - Helm Values Reveal Plaintext Secrets:** Changed raw reveal handling from a UI-confirmed plaintext path into a backend-enforced denial. `get_helm_release_values` validates input, denies `reveal: true` before client creation or value fetch, writes a denied `helm_values_reveal` audit entry, and returns a sanitized denial message. The frontend no longer sends reveal flags or renders reveal controls.
+- **F-04 - Raw Command Errors and Paths:** Sanitized Helm rollback/uninstall public error paths and frontend IPC error handling so UI and console output no longer include helper paths, kubeconfig paths, raw stdout/stderr, tokens, or secret-shaped details.
+- **F-08 - Resource Cache Raw GVK Allowlist:** Added `validate_cached_resource_gvk` backed by `ALL_WATCHED_GVKS` before cached list/get/count queries. Unsupported cached resource types now return the generic sanitized error `Unsupported cached resource type`; dynamic resource paths remain live API operations.
+
+### Supply Chain Integrity
+
+- **F-01 - Trusted Binary Resolver Test Fixture:** Replaced `current_exe()` trusted-binary test fixtures with dedicated temporary helper files using executable permissions and cleanup-on-drop. Production trusted-binary validation and permission checks were not weakened, including the kubeconfig exec-helper fixture uncovered by the final Rust gate.
+- **F-06 - Security and Supply-chain Scanning:** Added a CI security job that installs and runs `cargo audit`, installs pnpm dependencies with `pnpm install --frozen-lockfile`, and runs `pnpm audit --audit-level high`. Added weekly grouped Dependabot updates for Cargo and npm/pnpm workspaces.
+- **F-07 - K3D Integration Tests Not PR-gated:** Added a pull request trigger to the K3D integration workflow with path filters for engine/core/K3D fixture/workflow changes while preserving existing `main` push and manual dispatch behavior.
+
+## Validation
+
+### Final Global Gate
+
+Status: Passed
+
+- Pass: `./scripts/dev-test.sh` (container-first gate: Rust fmt/clippy/test, pnpm install, web unit tests, web E2E)
+- Pass: `cargo fmt --all -- --check`
+- Pass: `cargo clippy --workspace --exclude telescope-desktop --all-targets --all-features -- -D warnings`
+- Pass: `cargo test --workspace --exclude telescope-desktop --all-features`
+- Pass: `./scripts/pnpm.sh -C apps/web test` (8 files, 67 tests)
+- Pass: `./scripts/pnpm.sh -C apps/web build`
+- Pass: `./scripts/pnpm.sh -C apps/web e2e` (42 tests)
+
+### Containerized Desktop Checks
+
+- Pass in build container: `./scripts/dev-test.sh run bash -lc 'sudo chown -R pwuser:pwuser /home/pwuser/.cargo /home/pwuser/.rustup /home/pwuser/.local/share/pnpm/store && ./scripts/pnpm.sh -C apps/desktop prepare:frontend && cargo check -p telescope-desktop'`
+- Pass in build container: `./scripts/dev-test.sh run cargo build -p telescope-desktop`
+
+### Focused Verification
+
+- F-01: trusted binary resolver tests passed for `telescope-core`, `telescope-azure`, and kubeconfig exec-helper coverage in `telescope-engine`.
+- F-02: `cargo fmt --all -- --check` passed; host-only desktop check advances past `glib-sys` and remains blocked by missing `gdk-3.0.pc` before project code is checked.
+- F-03: `./scripts/pnpm.sh -C apps/web test` passed (8 files, 66 tests) and `./scripts/pnpm.sh -C apps/web e2e -- detail-reload.spec.ts` passed (4 tests).
+- F-04: `cargo test -p telescope-engine helm::tests -- --nocapture` passed (29 tests) and `./scripts/pnpm.sh -C apps/web test` passed (8 files, 67 tests).
+- F-05: `cargo test -p telescope-engine portforward -- --nocapture` passed (7 unit tests; integration filter ran 0 tests in this environment).
+- F-06: `git diff --check` passed and no-network YAML indentation sanity checks passed for `.github/workflows/ci.yml` and `.github/dependabot.yml`. Local `cargo audit` and `pnpm audit --audit-level high` were not run because they require network/tool download; the CI gates now run them.
+- F-07: `git diff --check` passed and static workflow inspection confirmed the new pull request trigger and path filters.
+- F-08: `cargo fmt --all -- --check`, `git diff --check`, and `./scripts/pnpm.sh -C apps/web e2e -- p2-routes.spec.ts` passed (12 tests).
+
+## Notes for Reviewers
+
+- The nonce/plaintext Helm values challenge discussed during review is not part of the current implementation. The shipped behavior in this branch is stricter: plaintext Helm values reveal is denied and audited.
+- Desktop remains the only supported runtime. The SvelteKit frontend continues to communicate with Rust through Tauri IPC, with no HTTP fallback.


### PR DESCRIPTION
# security: architectural hardening and vulnerability remediation (Sprint 2026-05-10)

Target branch: `main`
Source branch: `review/architecture-vulnerability-2026-05-10`

## Executive Summary

This PR closes the 2026-05-10 architecture vulnerability review by replacing fragile task-tail cleanup with ownership-based safety, tightening sensitive data boundaries, and adding release-gate coverage for dependency and integration regressions. The theme across the sprint is Security by Design: RAII guards own cleanup, supervisors own task lifecycles, sensitive operations produce mandatory audit trails, and user-facing errors expose safe categories instead of raw internals.

The largest behavior correction is Helm values handling. Telescope no longer exposes a plaintext Helm values reveal path. Normal values requests return recursively redacted YAML, while `reveal: true` requests are denied before values are fetched, logged as denied audit attempts, and surfaced as sanitized errors.

## Detailed Breakdown

### Memory/Task Safety

- **F-02 - Watcher Lifecycle Auxiliary Task Leak:** Replaced the stored raw watcher `JoinHandle` with `WatchTaskHandle`, an owner that contains the shared `CancellationToken` and every watcher/forwarder task handle. Reconnect, disconnect, namespace switch, replacement, and drop paths now cancel the token and abort owned tasks together.
- **F-05 - Port-forward Active Counter Panic/Abort Safety:** Added `ActiveForwardGuard` with atomic acquisition and `Drop` cleanup so port-forward slots are released on normal completion, early return, panic unwinding, and task abort/drop.

### API & Data Security

- **F-03 - Helm Values Reveal Plaintext Secrets:** Changed raw reveal handling from a UI-confirmed plaintext path into a backend-enforced denial. `get_helm_release_values` validates input, denies `reveal: true` before client creation or value fetch, writes a denied `helm_values_reveal` audit entry, and returns a sanitized denial message. The frontend no longer sends reveal flags or renders reveal controls.
- **F-04 - Raw Command Errors and Paths:** Sanitized Helm rollback/uninstall public error paths and frontend IPC error handling so UI and console output no longer include helper paths, kubeconfig paths, raw stdout/stderr, tokens, or secret-shaped details.
- **F-08 - Resource Cache Raw GVK Allowlist:** Added `validate_cached_resource_gvk` backed by `ALL_WATCHED_GVKS` before cached list/get/count queries. Unsupported cached resource types now return the generic sanitized error `Unsupported cached resource type`; dynamic resource paths remain live API operations.

### Supply Chain Integrity

- **F-01 - Trusted Binary Resolver Test Fixture:** Replaced `current_exe()` trusted-binary test fixtures with dedicated temporary helper files using executable permissions and cleanup-on-drop. Production trusted-binary validation and permission checks were not weakened, including the kubeconfig exec-helper fixture uncovered by the final Rust gate.
- **F-06 - Security and Supply-chain Scanning:** Added a CI security job that installs and runs `cargo audit`, installs pnpm dependencies with `pnpm install --frozen-lockfile`, and runs `pnpm audit --audit-level high`. Added weekly grouped Dependabot updates for Cargo and npm/pnpm workspaces.
- **F-07 - K3D Integration Tests Not PR-gated:** Added a pull request trigger to the K3D integration workflow with path filters for engine/core/K3D fixture/workflow changes while preserving existing `main` push and manual dispatch behavior.

## Validation

### Final Global Gate

Status: Passed

- Pass: `./scripts/dev-test.sh` (container-first gate: Rust fmt/clippy/test, pnpm install, web unit tests, web E2E)
- Pass: `cargo fmt --all -- --check`
- Pass: `cargo clippy --workspace --exclude telescope-desktop --all-targets --all-features -- -D warnings`
- Pass: `cargo test --workspace --exclude telescope-desktop --all-features`
- Pass: `./scripts/pnpm.sh -C apps/web test` (8 files, 67 tests)
- Pass: `./scripts/pnpm.sh -C apps/web build`
- Pass: `./scripts/pnpm.sh -C apps/web e2e` (42 tests)

### Containerized Desktop Checks

- Pass in build container: `./scripts/dev-test.sh run bash -lc 'sudo chown -R pwuser:pwuser /home/pwuser/.cargo /home/pwuser/.rustup /home/pwuser/.local/share/pnpm/store && ./scripts/pnpm.sh -C apps/desktop prepare:frontend && cargo check -p telescope-desktop'`
- Pass in build container: `./scripts/dev-test.sh run cargo build -p telescope-desktop`

### Focused Verification

- F-01: trusted binary resolver tests passed for `telescope-core`, `telescope-azure`, and kubeconfig exec-helper coverage in `telescope-engine`.
- F-02: `cargo fmt --all -- --check` passed; host-only desktop check advances past `glib-sys` and remains blocked by missing `gdk-3.0.pc` before project code is checked.
- F-03: `./scripts/pnpm.sh -C apps/web test` passed (8 files, 66 tests) and `./scripts/pnpm.sh -C apps/web e2e -- detail-reload.spec.ts` passed (4 tests).
- F-04: `cargo test -p telescope-engine helm::tests -- --nocapture` passed (29 tests) and `./scripts/pnpm.sh -C apps/web test` passed (8 files, 67 tests).
- F-05: `cargo test -p telescope-engine portforward -- --nocapture` passed (7 unit tests; integration filter ran 0 tests in this environment).
- F-06: `git diff --check` passed and no-network YAML indentation sanity checks passed for `.github/workflows/ci.yml` and `.github/dependabot.yml`. Local `cargo audit` and `pnpm audit --audit-level high` were not run because they require network/tool download; the CI gates now run them.
- F-07: `git diff --check` passed and static workflow inspection confirmed the new pull request trigger and path filters.
- F-08: `cargo fmt --all -- --check`, `git diff --check`, and `./scripts/pnpm.sh -C apps/web e2e -- p2-routes.spec.ts` passed (12 tests).

## Notes for Reviewers

- The nonce/plaintext Helm values challenge discussed during review is not part of the current implementation. The shipped behavior in this branch is stricter: plaintext Helm values reveal is denied and audited.
- Desktop remains the only supported runtime. The SvelteKit frontend continues to communicate with Rust through Tauri IPC, with no HTTP fallback.